### PR TITLE
Improve workspace sync

### DIFF
--- a/.manifest/chores-dev.yaml
+++ b/.manifest/chores-dev.yaml
@@ -45,6 +45,7 @@ settings:
     request_url: https://zaratan.ngrok.io/slack/events
     bot_events:
       - app_home_opened
+      - user_change
   interactivity:
     is_enabled: true
     request_url: https://zaratan.ngrok.io/slack/events

--- a/.manifest/chores.yaml
+++ b/.manifest/chores.yaml
@@ -45,6 +45,7 @@ settings:
     request_url: https://chores.mirror.zaratan.world/slack/events
     bot_events:
       - app_home_opened
+      - user_change
   interactivity:
     is_enabled: true
     request_url: https://chores.mirror.zaratan.world/slack/events

--- a/.manifest/hearts-dev.yaml
+++ b/.manifest/hearts-dev.yaml
@@ -35,6 +35,8 @@ settings:
     bot_events:
       - app_home_opened
       - message.channels
+      - user_change
+      - channel_created
   interactivity:
     is_enabled: true
     request_url: https://zaratan.ngrok.io/slack/events

--- a/.manifest/hearts.yaml
+++ b/.manifest/hearts.yaml
@@ -35,6 +35,8 @@ settings:
     bot_events:
       - app_home_opened
       - message.channels
+      - user_change
+      - channel_created
   interactivity:
     is_enabled: true
     request_url: https://hearts.mirror.zaratan.world/slack/events

--- a/.manifest/things-dev.yaml
+++ b/.manifest/things-dev.yaml
@@ -43,6 +43,7 @@ settings:
     request_url: https://zaratan.ngrok.io/slack/events
     bot_events:
       - app_home_opened
+      - user_change
   interactivity:
     is_enabled: true
     request_url: https://zaratan.ngrok.io/slack/events

--- a/.manifest/things.yaml
+++ b/.manifest/things.yaml
@@ -42,6 +42,7 @@ settings:
     request_url: https://things.mirror.zaratan.world/slack/events
     bot_events:
       - app_home_opened
+      - user_change
   interactivity:
     is_enabled: true
     request_url: https://things.mirror.zaratan.world/slack/events

--- a/src/bolt/chores.app.js
+++ b/src/bolt/chores.app.js
@@ -140,10 +140,7 @@ app.command('/chores-channel', async ({ ack, command }) => {
   await ack();
 
   await common.setChannel(app, choresConf.oauth, CHORES_CONF, command);
-
-  if (command.text !== 'help') {
-    await common.syncWorkspace(app, choresConf.oauth, command, true, false);
-  }
+  await common.syncWorkspace(app, choresConf.oauth, command, true, false);
 });
 
 app.command('/chores-stats', async ({ ack, command }) => {

--- a/src/bolt/chores.app.js
+++ b/src/bolt/chores.app.js
@@ -60,6 +60,15 @@ async function postEphemeral (residentId, text) {
   return common.postEphemeral(app, choresConf.oauth, choresConf.channel, residentId, text);
 }
 
+// Event listeners
+
+app.event('user_change', async ({ payload }) => {
+  console.log('chores user_change');
+
+  const { user } = payload;
+  await common.syncWorkspaceMember(user.team_id, user, new Date());
+});
+
 // Publish the app home
 
 app.event('app_home_opened', async ({ body, event }) => {
@@ -240,6 +249,7 @@ app.view('chores-reset-callback', async ({ ack, body }) => {
   const residentId = body.user.id;
 
   await Chores.resetChorePoints(houseId, now);
+
   await postMessage(`<@${residentId}> just reset all chore points :volcano:`);
 });
 
@@ -471,6 +481,7 @@ app.action('chores-propose', async ({ ack, body }) => {
 
   const now = new Date();
   const houseId = body.team.id;
+
   const minVotes = await Chores.getChoreProposalMinVotes(houseId, now);
 
   const view = views.choresProposeView(minVotes);

--- a/src/bolt/hearts.app.js
+++ b/src/bolt/hearts.app.js
@@ -136,10 +136,7 @@ app.command('/hearts-channel', async ({ ack, command }) => {
   await ack();
 
   await common.setChannel(app, heartsConf.oauth, HEARTS_CONF, command);
-
-  if (command.text !== 'help') {
-    await common.syncWorkspace(app, heartsConf.oauth, command, true, true);
-  }
+  await common.syncWorkspace(app, heartsConf.oauth, command, true, true);
 });
 
 // Challenge flow

--- a/src/bolt/hearts.app.js
+++ b/src/bolt/hearts.app.js
@@ -60,6 +60,22 @@ async function postEphemeral (residentId, text) {
   return common.postEphemeral(app, heartsConf.oauth, heartsConf.channel, residentId, text);
 }
 
+// Event listeners
+
+app.event('user_change', async ({ payload }) => {
+  console.log('hearts user_change');
+
+  const { user } = payload;
+  await common.syncWorkspaceMember(user.team_id, user, new Date());
+});
+
+app.event('channel_created', async ({ payload }) => {
+  console.log('hearts channel_created');
+
+  const { channel } = payload;
+  await common.joinChannel(app, heartsConf.oauth, channel.id);
+});
+
 // Publish the app home
 
 app.event('app_home_opened', async ({ body, event }) => {
@@ -117,6 +133,7 @@ app.event('app_home_opened', async ({ body, event }) => {
       const text = (karmaHearts.length > 1)
         ? `${karmaWinners} get last month's karma hearts :heart_on_fire:`
         : `${karmaWinners} gets last month's karma heart :heart_on_fire:`;
+
       await postMessage(text);
     }
   }
@@ -149,6 +166,7 @@ app.action('hearts-challenge', async ({ ack, body }) => {
   const houseId = body.team.id;
 
   const votingResidents = await Admin.getVotingResidents(houseId, now);
+
   const view = views.heartsChallengeView(votingResidents.length);
   await common.openView(app, heartsConf.oauth, body.trigger_id, view);
 });

--- a/src/bolt/things.app.js
+++ b/src/bolt/things.app.js
@@ -62,6 +62,15 @@ async function replyEphemeral (command, text) {
   return common.replyEphemeral(app, thingsConf.oauth, command, text);
 }
 
+// Event listeners
+
+app.event('user_change', async ({ payload }) => {
+  console.log('things user_change');
+
+  const { user } = payload;
+  await common.syncWorkspaceMember(user.team_id, user, new Date());
+});
+
 // Publish the app home
 
 app.event('app_home_opened', async ({ body, event }) => {


### PR DESCRIPTION
Closes #162

Add a `user_change` event listener to update the user list on user change. This is in lieu of integrating workspace sync calls, which run the risk of hitting rate limits.

Additionally, add a `channel_change` event listener to add the Hearts app to channels on creation.

Listening to change events and updating accordingly aligns more closely with best practices and avoids redundant RPC activity. The existing `sync` functionality exists in cases where the the database falls out of sync due to missed events.

In the future we may add selective (~monthly) sync actions to a cron job (using `node-cron`) to further automate this process, but that is overkill for now.