### PR TITLE
Rearchitect chore valuation, add support for Special Chores

### DIFF
--- a/migrations/20200329100520_ChoreValue.js
+++ b/migrations/20200329100520_ChoreValue.js
@@ -3,7 +3,7 @@ exports.up = function(knex, Promise) {
         t.increments('id').unsigned().primary();
         t.timestamps(useTimestamps = true, defaultToNow = true, useCamelCase = true);
         t.string('houseId').references('House.slackId').notNull();
-        t.integer('choreId').references('Chore.id').notNull();
+        t.integer('choreId').references('Chore.id');
         t.timestamp('valuedAt').notNull();
         t.float('value').notNull();
         t.jsonb('metadata').notNull().defaultTo({});

--- a/migrations/20200329100530_ChoreClaim.js
+++ b/migrations/20200329100530_ChoreClaim.js
@@ -4,6 +4,7 @@ exports.up = function(knex, Promise) {
         t.timestamps(useTimestamps = true, defaultToNow = true, useCamelCase = true);
         t.string('houseId').references('House.slackId').notNull();;
         t.integer('choreId').references('Chore.id');
+        // t.integer('choreValueId').references('ChoreValue.id');
         t.string('claimedBy').references('Resident.slackId');
         t.timestamp('claimedAt');
         t.float('value');
@@ -11,6 +12,7 @@ exports.up = function(knex, Promise) {
         t.timestamp('resolvedAt');
         t.boolean('valid').notNull().defaultTo(true);
         t.jsonb('metadata').notNull().defaultTo({});
+        // t.check('?? IS NULL OR ?? IS NULL', ['choreId', 'choreValueId'], 'choreId_choreValueId_check');
     });
 };
 

--- a/migrations/20241018150452_choreValueId.js
+++ b/migrations/20241018150452_choreValueId.js
@@ -1,0 +1,26 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  return knex.schema.table('ChoreClaim', function(t) {
+    t.integer('choreValueId').references('ChoreValue.id');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.schema.table('ChoreClaim', function(t) {
+    t.dropColumn('choreValueId');
+  });
+};
+
+
+// Add this manually
+
+// ALTER TABLE "ChoreClaim"
+// ADD CONSTRAINT "choreId_choreValueId_check"
+// CHECK ("choreId" IS NULL OR "choreValueId" IS NULL);

--- a/src/bolt/chores.views.js
+++ b/src/bolt/chores.views.js
@@ -267,7 +267,7 @@ exports.choresClaimView2 = function (chore) {
 
   const blocks = [];
   blocks.push(common.blockHeader(header));
-  blocks.push(common.blockSection(`*${chore.name}*`));
+  blocks.push(common.blockSection(`*${chore.name || chore.metadata.name}*`));
   blocks.push(common.blockSection(chore.metadata.description || ''));
 
   return {
@@ -298,11 +298,11 @@ exports.getSparkles = function (monthlyPoints) {
   return ':sparkles:'.repeat(Math.max(numSparkles, 0)); // Handle negative points
 };
 
-exports.choresClaimCallbackView = function (claim, choreName, minVotes, achivementPoints, monthlyPoints) {
+exports.choresClaimCallbackView = function (claim, name, minVotes, achivementPoints, monthlyPoints) {
   const achievement = exports.getAchievement(achivementPoints);
   const sparkles = exports.getSparkles(monthlyPoints);
 
-  const mainText = `*<@${claim.claimedBy}>* did *${choreName}* for ` +
+  const mainText = `*<@${claim.claimedBy}>* did *${name}* for ` +
     `*${claim.value.toFixed(0)} points* ${achievement}${sparkles}`;
 
   const blocks = [];
@@ -827,9 +827,10 @@ function mapChores (chores) {
 
 function mapChoresValues (chores) {
   return chores.map((chore) => {
+    const name = chore.name || chore.metadata.name;
     return {
-      value: JSON.stringify({ id: chore.id }),
-      text: common.blockPlaintext(`${chore.name} - ${chore.value.toFixed(0)} points`),
+      value: JSON.stringify({ choreId: chore.choreId, choreValueId: chore.choreValueId }),
+      text: common.blockPlaintext(`${name} - ${chore.value.toFixed(0)} points`),
     };
   });
 }

--- a/src/config.js
+++ b/src/config.js
@@ -18,6 +18,10 @@ exports.choreProposalPct = 0.4;
 exports.breakMinDays = 3;
 exports.pointsBuffer = 20;
 exports.pingInterval = 25;
+exports.specialChoreMaxValueProportion = 0.2;
+exports.specialChoreVoteIncrement = 25;
+exports.choreSpecialPctMin = 0.3; // Minimum threshold for special chores
+exports.choreSpecialPctMax = 0.6; // Maximum threshold for special chores
 
 // Hearts
 exports.heartsPollLength = 3 * DAY;

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,6 +24,10 @@ exports.shiftDate = function (date, minutes) {
   return new Date(date.getTime() + minutes * MINUTE);
 };
 
+exports.truncateHour = function (date) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours());
+};
+
 exports.sleep = async function (ms) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);

--- a/test/hearts.test.js
+++ b/test/hearts.test.js
@@ -346,7 +346,7 @@ describe('Hearts', async () => {
       expect(minVotes).to.equal(4);
 
       // Exempt users are not counted
-      await testHelpers.createExemptUsers(HOUSE, 10);
+      await testHelpers.createExemptUsers(HOUSE, 10, now);
       minVotes = await Hearts.getChallengeMinVotes(HOUSE, RESIDENT2, 2, now);
       expect(minVotes).to.equal(2);
     });

--- a/test/hearts.test.js
+++ b/test/hearts.test.js
@@ -347,7 +347,7 @@ describe('Hearts', async () => {
 
       // Exempt users are not counted
       await testHelpers.createExemptUsers(HOUSE, 10, now);
-      minVotes = await Hearts.getChallengeMinVotes(HOUSE, RESIDENT2, 2, now);
+      minVotes = await Hearts.getChallengeMinVotes(HOUSE, RESIDENT2, 2, soon);
       expect(minVotes).to.equal(2);
     });
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -10,6 +10,13 @@ exports.generateSlackId = function () {
   });
 };
 
+exports.createActiveUsers = async function (houseId, num, now) {
+  for (let i = 0; i < num; i++) {
+    const residentId = exports.generateSlackId();
+    await Admin.activateResident(houseId, residentId, now);
+  }
+};
+
 exports.createExemptUsers = async function (houseId, num, now) {
   for (let i = 0; i < num; i++) {
     const residentId = exports.generateSlackId();

--- a/test/things.test.js
+++ b/test/things.test.js
@@ -150,14 +150,14 @@ describe('Things', async () => {
     it('can get the minimum votes for a buy', async () => {
       let minVotes;
 
-      minVotes = await Things.getThingBuyMinVotes(HOUSE, rice.id, 10, soon);
+      minVotes = await Things.getThingBuyMinVotes(HOUSE, rice.id, 10, now);
       expect(minVotes).to.equal(1);
 
-      minVotes = await Things.getThingBuyMinVotes(HOUSE, rice.id, 70, soon);
+      minVotes = await Things.getThingBuyMinVotes(HOUSE, rice.id, 70, now);
       expect(minVotes).to.equal(2);
 
       // max: ceil( 4 residents * 60% ) = 3
-      minVotes = await Things.getThingBuyMinVotes(HOUSE, rice.id, 200, soon);
+      minVotes = await Things.getThingBuyMinVotes(HOUSE, rice.id, 200, now);
       expect(minVotes).to.equal(3);
 
       // Exempt users are not counted
@@ -418,14 +418,14 @@ describe('Things', async () => {
       let minVotes;
 
       // min: ceil( 4 residents * 30% ) = 2
-      minVotes = await Things.getThingBuyMinVotes(HOUSE, null, 10, soon);
+      minVotes = await Things.getThingBuyMinVotes(HOUSE, null, 10, now);
       expect(minVotes).to.equal(2);
 
-      minVotes = await Things.getThingBuyMinVotes(HOUSE, null, 100, soon);
+      minVotes = await Things.getThingBuyMinVotes(HOUSE, null, 100, now);
       expect(minVotes).to.equal(2);
 
       // max: ceil( 4 residents * 60% ) = 3
-      minVotes = await Things.getThingBuyMinVotes(HOUSE, null, 300, soon);
+      minVotes = await Things.getThingBuyMinVotes(HOUSE, null, 300, now);
       expect(minVotes).to.equal(3);
 
       // Exempt users are not counted
@@ -598,7 +598,7 @@ describe('Things', async () => {
 
       // Exempt users are not counted
       await testHelpers.createExemptUsers(HOUSE, 10, now);
-      minVotes = await Things.getThingProposalMinVotes(HOUSE, now);
+      minVotes = await Things.getThingProposalMinVotes(HOUSE, soon);
       expect(minVotes).to.equal(2);
     });
 

--- a/test/things.test.js
+++ b/test/things.test.js
@@ -150,19 +150,19 @@ describe('Things', async () => {
     it('can get the minimum votes for a buy', async () => {
       let minVotes;
 
-      minVotes = await Things.getThingBuyMinVotes(HOUSE, rice.id, 10, now);
+      minVotes = await Things.getThingBuyMinVotes(HOUSE, rice.id, 10, soon);
       expect(minVotes).to.equal(1);
 
-      minVotes = await Things.getThingBuyMinVotes(HOUSE, rice.id, 70, now);
+      minVotes = await Things.getThingBuyMinVotes(HOUSE, rice.id, 70, soon);
       expect(minVotes).to.equal(2);
 
       // max: ceil( 4 residents * 60% ) = 3
-      minVotes = await Things.getThingBuyMinVotes(HOUSE, rice.id, 200, now);
+      minVotes = await Things.getThingBuyMinVotes(HOUSE, rice.id, 200, soon);
       expect(minVotes).to.equal(3);
 
       // Exempt users are not counted
-      await testHelpers.createExemptUsers(HOUSE, 10);
-      minVotes = await Things.getThingBuyMinVotes(HOUSE, rice.id, 500, now);
+      await testHelpers.createExemptUsers(HOUSE, 10, now);
+      minVotes = await Things.getThingBuyMinVotes(HOUSE, rice.id, 500, soon);
       expect(minVotes).to.equal(3);
     });
 
@@ -418,19 +418,19 @@ describe('Things', async () => {
       let minVotes;
 
       // min: ceil( 4 residents * 30% ) = 2
-      minVotes = await Things.getThingBuyMinVotes(HOUSE, null, 10, now);
+      minVotes = await Things.getThingBuyMinVotes(HOUSE, null, 10, soon);
       expect(minVotes).to.equal(2);
 
-      minVotes = await Things.getThingBuyMinVotes(HOUSE, null, 100, now);
+      minVotes = await Things.getThingBuyMinVotes(HOUSE, null, 100, soon);
       expect(minVotes).to.equal(2);
 
       // max: ceil( 4 residents * 60% ) = 3
-      minVotes = await Things.getThingBuyMinVotes(HOUSE, null, 300, now);
+      minVotes = await Things.getThingBuyMinVotes(HOUSE, null, 300, soon);
       expect(minVotes).to.equal(3);
 
       // Exempt users are not counted
-      await testHelpers.createExemptUsers(HOUSE, 10);
-      minVotes = await Things.getThingBuyMinVotes(HOUSE, null, 500, now);
+      await testHelpers.createExemptUsers(HOUSE, 10, now);
+      minVotes = await Things.getThingBuyMinVotes(HOUSE, null, 500, soon);
       expect(minVotes).to.equal(3);
     });
 
@@ -597,7 +597,7 @@ describe('Things', async () => {
       expect(minVotes).to.equal(2);
 
       // Exempt users are not counted
-      await testHelpers.createExemptUsers(HOUSE, 10);
+      await testHelpers.createExemptUsers(HOUSE, 10, now);
       minVotes = await Things.getThingProposalMinVotes(HOUSE, now);
       expect(minVotes).to.equal(2);
     });


### PR DESCRIPTION
Closes #210 

This PR makes significant changes to the underlying chore valuation mechanics, as well as introducing support for "special chores."

At a high level, chore valuation has been re-architected such that instead of issuing points proportionally over the course of the month, points are now issue proportionally over the _remainder of the month_, with the given point value being the _difference_ between expected total monthly points and the sum of all points issued thus far in the month. This logic makes it possible to introduce "special chores" and have them be included in the total number of already-issued points.

More specifically, the new points calculation introduces a number of new concepts and relationships:

```
wt = sum_a{t_m - max(t_a, t_0)}
// working time is the sum across all active users of their time active in the month

p_m = wt / (t_m - t_0) * ppr * inf
// monthly points is working time divided by the length of the month, times points per month and inflation

p_u = sum{r} + sum{s}
// used points is the sum of the regular and special chore values to-date in the month

p_r = p_m - p_u
// remaining points is the difference between monthly points and used points

is = t_n - t_l / t_m - t_l
// interval scalar is the time since the last update, divided by the time left in the month 

p_a = p_r / is
// available points is the remaining points divided by the interval scalar
```

These relations are implemented in the `getAvailablePoints` function, which takes the current update time, as well as the time of the last update.

Fundamentally, available points are now the interaction of two factors: a decreasing remaining points and an increasing interval scalar.

Some notes about this implementation:

- Reductions in point issuance due to breaks is determined only by active breaks _on the day of the update_. For houses which calculate chore updates more frequently than once every 24 hours, this will have no effect. The risk of over- or -under-estimation of break time due to long update intervals is acceptable for communities which use their app less regularly.

- For update intervals spanning multiple months, the points available must be calculated separately for each period. Otherwise, there is a possibility of over-issuing points and reducing later point issuance.

- User `activeAt` and `exemptAt` are now truncated to the hour before saving. This is due to an interaction between the use of `activeAt` as the basis for calculating point issuance and the desire to "bootstrap" chore points for new communities.

- We add a `choreValueId` column to the `ChoreClaim` table, allowing claims to reference both regular and special chores.

- Special chore values are limited to 20% of the available points, to minimize disruption on regular points issuance

- This change can be made in-place, and will pick up where the older system left off