### PR TITLE
Introduce upvote threshold scaling

### DIFF
--- a/src/bolt/hearts.app.js
+++ b/src/bolt/hearts.app.js
@@ -128,7 +128,7 @@ app.event('app_home_opened', async ({ body, event }) => {
     const maxHearts = await Hearts.getResidentMaxHearts(residentId, now);
     const exempt = await Admin.isExempt(residentId, now);
 
-    view = views.heartsHomeView(hearts.sum || 0, maxHearts, exempt);
+    view = views.heartsHomeView(hearts || 0, maxHearts, exempt);
   } else {
     view = views.heartsIntroView();
   }

--- a/src/config.js
+++ b/src/config.js
@@ -36,6 +36,7 @@ exports.karmaProportion = 3;
 exports.heartsMaxBase = 7;
 exports.heartsMaxLimit = 10;
 exports.heartsKarmaGrowthRate = 4;
+exports.heartsVoteScalar = 0.2;
 
 // Things
 exports.thingsPollLength = 6 * HOUR;

--- a/src/core/chores.js
+++ b/src/core/chores.js
@@ -592,7 +592,7 @@ exports.addChorePenalty = async function (houseId, residentId, currentTime) {
   const penaltyHeart = await Hearts.getHeart(residentId, penaltyTime);
   if (!penaltyHeart) {
     const hearts = await Hearts.getHearts(residentId, penaltyTime);
-    if (hearts.sum === null) { return []; } // Don't penalize if not initialized
+    if (hearts === null) { return []; } // Don't penalize if not initialized
 
     const penaltyAmount = await exports.calculatePenalty(residentId, penaltyTime);
     return Hearts.generateHearts(houseId, residentId, HEART_CHORE, penaltyTime, -penaltyAmount);

--- a/src/core/hearts.js
+++ b/src/core/hearts.js
@@ -18,6 +18,7 @@ const {
   heartsMaxLimit,
   heartsKarmaGrowthRate,
   heartsCriticalNum,
+  heartsVoteScalar,
 } = require('../config');
 
 const Admin = require('./admin');
@@ -99,6 +100,12 @@ exports.getRegenAmount = function (currentHearts) {
   return (baselineGap >= 0)
     ? Math.min(heartsRegenAmount, baselineGap)
     : Math.max(-heartsFadeAmount, baselineGap);
+};
+
+exports.getHeartsVoteScalar = async function (residentId, now) {
+  const hearts = await exports.getHearts(residentId, now);
+  const heartsValue = (hearts.sum === null) ? heartsBaselineAmount : hearts.sum;
+  return 1 - ((heartsValue - heartsBaselineAmount) * heartsVoteScalar);
 };
 
 // Challenges

--- a/test/hearts.test.js
+++ b/test/hearts.test.js
@@ -143,6 +143,39 @@ describe('Hearts', async () => {
       active = await Admin.houseActive(HOUSE, 'Heart', 'generatedAt', tomorrow, nextWeek);
       expect(active).to.be.false;
     });
+
+    it('can use hearts to scale required votes', async () => {
+      let voteScalar;
+
+      // Return 1 if not initialised
+      voteScalar = await Hearts.getHeartsVoteScalar(RESIDENT1, now);
+      expect(voteScalar).to.equal(1);
+
+      // 0 hearts
+      await Hearts.generateHearts(HOUSE, RESIDENT1, HEART_UNKNOWN, now, 0);
+      voteScalar = await Hearts.getHeartsVoteScalar(RESIDENT1, now);
+      expect(voteScalar).to.equal(2);
+
+      // 3 hearts
+      await Hearts.generateHearts(HOUSE, RESIDENT1, HEART_UNKNOWN, now, 3);
+      voteScalar = await Hearts.getHeartsVoteScalar(RESIDENT1, now);
+      expect(voteScalar).to.equal(1.4);
+
+      // Return 5 hearts
+      await Hearts.generateHearts(HOUSE, RESIDENT1, HEART_UNKNOWN, now, 2);
+      voteScalar = await Hearts.getHeartsVoteScalar(RESIDENT1, now);
+      expect(voteScalar).to.equal(1);
+
+      // 7 hearts
+      await Hearts.generateHearts(HOUSE, RESIDENT1, HEART_UNKNOWN, now, 2);
+      voteScalar = await Hearts.getHeartsVoteScalar(RESIDENT1, now);
+      expect(voteScalar).to.equal(0.6);
+
+      // 10 hearts
+      await Hearts.generateHearts(HOUSE, RESIDENT1, HEART_UNKNOWN, now, 3);
+      voteScalar = await Hearts.getHeartsVoteScalar(RESIDENT1, now);
+      expect(voteScalar).to.equal(0);
+    });
   });
 
   describe('regenerating hearts', async () => {

--- a/test/hearts.test.js
+++ b/test/hearts.test.js
@@ -56,9 +56,9 @@ describe('Hearts', async () => {
       const hearts2 = await Hearts.getHearts(RESIDENT2, now);
       const hearts3 = await Hearts.getHearts(RESIDENT3, now);
 
-      expect(hearts1.sum).to.equal(2);
-      expect(hearts2.sum).to.equal(1);
-      expect(hearts3.sum).to.equal(null);
+      expect(hearts1).to.equal(2);
+      expect(hearts2).to.equal(1);
+      expect(hearts3).to.equal(null);
     });
 
     it('can query for specific hearts', async () => {
@@ -97,7 +97,7 @@ describe('Hearts', async () => {
 
       const hearts = await Hearts.getHearts(RESIDENT1, now);
 
-      expect(hearts.sum).to.equal(1);
+      expect(hearts).to.equal(1);
     });
 
     it('can handle fractional hearts', async () => {
@@ -106,7 +106,7 @@ describe('Hearts', async () => {
 
       const hearts = await Hearts.getHearts(RESIDENT1, now);
 
-      expect(hearts.sum).to.equal(1.75);
+      expect(hearts).to.equal(1.75);
     });
 
     it('can initialise a resident', async () => {
@@ -114,13 +114,13 @@ describe('Hearts', async () => {
 
       let hearts;
       hearts = await Hearts.getHearts(RESIDENT1, now);
-      expect(hearts.sum).to.equal(heartsBaselineAmount);
+      expect(hearts).to.equal(heartsBaselineAmount);
 
       // But only once
       await Hearts.initialiseResident(HOUSE, RESIDENT1, now);
 
       hearts = await Hearts.getHearts(RESIDENT1, now);
-      expect(hearts.sum).to.equal(heartsBaselineAmount);
+      expect(hearts).to.equal(heartsBaselineAmount);
 
       // Even if they go back to zero
       await Hearts.generateHearts(HOUSE, RESIDENT1, HEART_UNKNOWN, now, -heartsBaselineAmount);
@@ -128,7 +128,7 @@ describe('Hearts', async () => {
       await Hearts.initialiseResident(HOUSE, RESIDENT1, now);
 
       hearts = await Hearts.getHearts(RESIDENT1, now);
-      expect(hearts.sum).to.equal(0);
+      expect(hearts).to.equal(0);
     });
 
     it('can check if a house is active using hearts', async () => {
@@ -194,7 +194,7 @@ describe('Hearts', async () => {
       await Hearts.regenerateHearts(HOUSE, RESIDENT1, nextMonth);
 
       hearts = await Hearts.getHearts(RESIDENT1, nextMonth);
-      expect(hearts.sum).to.equal(null);
+      expect(hearts).to.equal(null);
 
       // Generate a heart, now regeneration works
       await Hearts.generateHearts(HOUSE, RESIDENT1, HEART_UNKNOWN, now, 1);
@@ -202,19 +202,19 @@ describe('Hearts', async () => {
       await Hearts.regenerateHearts(HOUSE, RESIDENT1, nextMonth);
 
       hearts = await Hearts.getHearts(RESIDENT1, nextMonth);
-      expect(hearts.sum).to.equal(1.25);
+      expect(hearts).to.equal(1.25);
 
       // But not in the same month
       await Hearts.regenerateHearts(HOUSE, RESIDENT1, nextMonth);
 
       hearts = await Hearts.getHearts(RESIDENT1, nextMonth);
-      expect(hearts.sum).to.equal(1.25);
+      expect(hearts).to.equal(1.25);
 
       // But yes in another month
       await Hearts.regenerateHearts(HOUSE, RESIDENT1, twoMonths);
 
       hearts = await Hearts.getHearts(RESIDENT1, twoMonths);
-      expect(hearts.sum).to.equal(1.5);
+      expect(hearts).to.equal(1.5);
     });
 
     it('cannot regenerate hearts if full', async () => {
@@ -223,23 +223,23 @@ describe('Hearts', async () => {
       await Hearts.initialiseResident(HOUSE, RESIDENT1, now);
 
       hearts = await Hearts.getHearts(RESIDENT1, now);
-      expect(hearts.sum).to.equal(5);
+      expect(hearts).to.equal(5);
 
       await Hearts.regenerateHearts(HOUSE, RESIDENT1, now);
 
       hearts = await Hearts.getHearts(RESIDENT1, now);
-      expect(hearts.sum).to.equal(5);
+      expect(hearts).to.equal(5);
 
       // Or overloaded
       await Hearts.generateHearts(HOUSE, RESIDENT1, HEART_UNKNOWN, nextMonth, 1);
 
       hearts = await Hearts.getHearts(RESIDENT1, nextMonth);
-      expect(hearts.sum).to.equal(6);
+      expect(hearts).to.equal(6);
 
       await Hearts.regenerateHearts(HOUSE, RESIDENT1, nextMonth);
 
       hearts = await Hearts.getHearts(RESIDENT1, nextMonth);
-      expect(hearts.sum).to.equal(6);
+      expect(hearts).to.equal(6);
     });
 
     it('can regenerate hearts in bulk', async () => {
@@ -289,8 +289,8 @@ describe('Hearts', async () => {
 
       const hearts1 = await Hearts.getHearts(RESIDENT1, challengeEnd);
       const hearts2 = await Hearts.getHearts(RESIDENT2, challengeEnd);
-      expect(hearts1.sum).to.equal(5);
-      expect(hearts2.sum).to.equal(4);
+      expect(hearts1).to.equal(5);
+      expect(hearts2).to.equal(4);
     });
 
     it('can resolve a challenge where the challenger loses', async () => {
@@ -304,8 +304,8 @@ describe('Hearts', async () => {
 
       const hearts1 = await Hearts.getHearts(RESIDENT1, challengeEnd);
       const hearts2 = await Hearts.getHearts(RESIDENT2, challengeEnd);
-      expect(hearts1.sum).to.equal(4);
-      expect(hearts2.sum).to.equal(5);
+      expect(hearts1).to.equal(4);
+      expect(hearts2).to.equal(5);
     });
 
     it('can resolve a challenge where minVotes is not reached', async () => {
@@ -318,8 +318,8 @@ describe('Hearts', async () => {
 
       const hearts1 = await Hearts.getHearts(RESIDENT1, challengeEnd);
       const hearts2 = await Hearts.getHearts(RESIDENT2, challengeEnd);
-      expect(hearts1.sum).to.equal(4);
-      expect(hearts2.sum).to.equal(5);
+      expect(hearts1).to.equal(4);
+      expect(hearts2).to.equal(5);
     });
 
     it('can resolve challenges in bulk', async () => {
@@ -338,9 +338,9 @@ describe('Hearts', async () => {
       const hearts1 = await Hearts.getHearts(RESIDENT1, challengeEnd);
       const hearts2 = await Hearts.getHearts(RESIDENT2, challengeEnd);
       const hearts3 = await Hearts.getHearts(RESIDENT3, challengeEnd);
-      expect(hearts1.sum).to.equal(5);
-      expect(hearts2.sum).to.equal(4);
-      expect(hearts3.sum).to.equal(3);
+      expect(hearts1).to.equal(5);
+      expect(hearts2).to.equal(4);
+      expect(hearts3).to.equal(3);
     });
 
     it('cannot resolve a challenge before the poll is closed', async () => {


### PR DESCRIPTION
Closes #211 

Will scale upvotes needed for Things buys based on the number of hearts a user has, with a multiplier ranging from (0, 2) mapping linearly (0.2) to (0, 10) possible hearts.

Note that if a workspace installs Hearts and then later uninstalls it, there is no way currently for Things to stop using Hearts values. One possible solution for this would be to reset Hearts to baseline upon app uninstall (see #220).