### PR TITLE
Revive after losing hearts

### DIFF
--- a/src/bolt/hearts.app.js
+++ b/src/bolt/hearts.app.js
@@ -169,6 +169,13 @@ app.event('app_home_opened', async ({ body, event }) => {
 
     await postMessage(text);
   }
+
+  // Revive any residents
+  for (const revivalHeart of (await Hearts.reviveResidents(houseId, now))) {
+    const text = `Hello <!channel>! *<@${revivalHeart.residentId}> lost all their hearts*, ` +
+      'and has been revived to three. :fairy:';
+    await postMessage(text);
+  }
 });
 
 // Slash commands

--- a/src/config.js
+++ b/src/config.js
@@ -26,6 +26,7 @@ exports.choreSpecialPctMax = 0.6; // Maximum threshold for special chores
 // Hearts
 exports.heartsPollLength = 3 * DAY;
 exports.heartsBaselineAmount = 5;
+exports.heartsReviveAmount = 3;
 exports.heartsRegenAmount = 0.25;
 exports.heartsFadeAmount = 0.25;
 exports.heartsMinPctInitial = 0.4; // For removing initial hearts

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,6 +14,7 @@ exports.HEART_REGEN = 1;
 exports.HEART_CHALLENGE = 2;
 exports.HEART_KARMA = 3;
 exports.HEART_CHORE = 4;
+exports.HEART_REVIVE = 5;
 
 exports.CHORES_CONF = 'choresConf';
 exports.HEARTS_CONF = 'heartsConf';

--- a/test/hearts.test.js
+++ b/test/hearts.test.js
@@ -5,8 +5,8 @@ const chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 
 const { Hearts, Polls, Admin } = require('../src/core/index');
-const { NAY, YAY, HOUR, DAY, HEART_UNKNOWN, HEART_KARMA, HEART_CHALLENGE } = require('../src/constants');
-const { heartsPollLength, heartsBaselineAmount, heartsMaxBase, karmaDelay } = require('../src/config');
+const { NAY, YAY, HOUR, DAY, HEART_UNKNOWN, HEART_KARMA, HEART_CHALLENGE, HEART_REVIVE } = require('../src/constants');
+const { heartsPollLength, heartsBaselineAmount, heartsReviveAmount, heartsMaxBase, karmaDelay } = require('../src/config');
 const { getNextMonthStart } = require('../src/utils');
 const testHelpers = require('./helpers');
 
@@ -129,6 +129,29 @@ describe('Hearts', async () => {
 
       hearts = await Hearts.getHearts(RESIDENT1, now);
       expect(hearts).to.equal(0);
+    });
+
+    it('can revive a resident', async () => {
+      await Hearts.initialiseResident(HOUSE, RESIDENT1, now);
+
+      let heart;
+      let hearts;
+
+      await Hearts.generateHearts(HOUSE, RESIDENT1, HEART_UNKNOWN, now, -heartsBaselineAmount);
+
+      // Will revive at 0 hearts
+      [ heart ] = await Hearts.reviveResident(HOUSE, RESIDENT1, now);
+      expect(heart.type).to.equal(HEART_REVIVE);
+
+      hearts = await Hearts.getHearts(RESIDENT1, now);
+      expect(hearts).to.equal(heartsReviveAmount);
+
+      // But not twice
+      [ heart ] = await Hearts.reviveResident(HOUSE, RESIDENT1, now);
+      expect(heart).to.be.undefined;
+
+      hearts = await Hearts.getHearts(RESIDENT1, now);
+      expect(hearts).to.equal(heartsReviveAmount);
     });
 
     it('can check if a house is active using hearts', async () => {

--- a/test/hearts.test.js
+++ b/test/hearts.test.js
@@ -140,14 +140,14 @@ describe('Hearts', async () => {
       await Hearts.generateHearts(HOUSE, RESIDENT1, HEART_UNKNOWN, now, -heartsBaselineAmount);
 
       // Will revive at 0 hearts
-      [ heart ] = await Hearts.reviveResident(HOUSE, RESIDENT1, now);
+      [ heart ] = await Hearts.reviveResidents(HOUSE, now);
       expect(heart.type).to.equal(HEART_REVIVE);
 
       hearts = await Hearts.getHearts(RESIDENT1, now);
       expect(hearts).to.equal(heartsReviveAmount);
 
       // But not twice
-      [ heart ] = await Hearts.reviveResident(HOUSE, RESIDENT1, now);
+      [ heart ] = await Hearts.reviveResidents(HOUSE, now);
       expect(heart).to.be.undefined;
 
       hearts = await Hearts.getHearts(RESIDENT1, now);


### PR DESCRIPTION
Closes #229

- Introduce `reviveResident` to "revive" a resident to 3 hearts after running out.
- Whenever the Hearts app home is opened, revive any expires residents and post to the channel.

TODO: is there are more efficient way to automate this behavior? Cron?