### PR TITLE
Improve slash command handling

### DIFF
--- a/src/bolt/hearts.app.js
+++ b/src/bolt/hearts.app.js
@@ -178,33 +178,33 @@ app.event('app_home_opened', async ({ body, event }) => {
 
 // Slash commands
 
-app.command('/hearts-sync', async ({ ack, command }) => {
+app.command('/hearts-sync', async ({ ack, command, respond }) => {
   await ack();
 
   const commandName = '/hearts-sync';
   common.beginCommand(commandName, command);
 
   const text = await common.syncWorkspaceChannels(app, heartsConf.oauth);
-  await common.replyEphemeral(app, heartsConf.oauth, command, text);
+  await respond({ response_type: 'ephemeral', text });
 });
 
-app.command('/hearts-prune', async ({ ack, command }) => {
+app.command('/hearts-prune', async ({ ack, command, respond }) => {
   await ack();
 
   const commandName = '/hearts-prune';
   const { now, houseId } = common.beginCommand(commandName, command);
 
   const text = await common.pruneWorkspaceMembers(app, heartsConf.oauth, houseId, now);
-  await common.replyEphemeral(app, heartsConf.oauth, command, text);
+  await respond({ response_type: 'ephemeral', text });
 });
 
-app.command('/hearts-channel', async ({ ack, command }) => {
+app.command('/hearts-channel', async ({ ack, command, respond }) => {
   await ack();
 
   const commandName = '/hearts-channel';
   common.beginCommand(commandName, command);
 
-  await common.setChannel(app, heartsConf.oauth, HEARTS_CONF, command);
+  await common.setChannel(app, heartsConf.oauth, HEARTS_CONF, command, respond);
 });
 
 // Challenge flow

--- a/src/bolt/things.app.js
+++ b/src/bolt/things.app.js
@@ -180,10 +180,11 @@ app.command('/things-fulfill', async ({ ack, command, respond }) => {
     return;
   }
 
-  const unfulfilledBuys = await Things.getUnfulfilledThingBuys(houseId, now);
+  const confirmedBuys = (await Things.getUnfulfilledThingBuys(houseId, now))
+    .filter(buy => buy.resolvedAt);
 
-  if (unfulfilledBuys.length) {
-    const view = views.thingsFulfillView(unfulfilledBuys);
+  if (confirmedBuys.length) {
+    const view = views.thingsFulfillView(confirmedBuys);
     await common.openView(app, thingsConf.oauth, command.trigger_id, view);
   } else {
     await respond({ response_type: 'ephemeral', text: 'There are no buys to fulfill :relieved:' });


### PR DESCRIPTION
Partially addresses #189 

This PR improves slash command handling:

- Uses the built-in `respond` function in lieu of our own `replyEphemeral` when responding to slash commands
- Improves UX around setting app channels, both by making the current channel more visible and when using private channels

One initial motivation was wanting to provide more helpful error messages to the user. Bolt's built-in `respond` functions allows responding to users even if the app is not currently a member of the channel. This improves some strange behaviors first documented in #173, and should make it easier for users to get up-and-running.

A nice benefit of this change is it allows us to fully deprecate the `replyEphemeral` function, which was only used to respond to slash commands privately -- functionality which is better provided by `respond`.