### PR TITLE
Add hearts reset

### DIFF
--- a/.manifest/hearts-dev.yaml
+++ b/.manifest/hearts-dev.yaml
@@ -20,6 +20,9 @@ features:
     - command: /hearts-sync
       url: https://zaratan.ngrok.io/slack/events
       description: Sync workspace members or channels
+    - command: /hearts-reset
+      url: https://zaratan.ngrok.io/slack/events
+      description: Reset hearts for all residents
 oauth_config:
   redirect_urls:
     - https://zaratan.ngrok.io/slack/oauth_redirect

--- a/.manifest/hearts.yaml
+++ b/.manifest/hearts.yaml
@@ -20,6 +20,9 @@ features:
     - command: /hearts-sync
       url: https://hearts.mirror.zaratan.world/slack/events
       description: Sync workspace members or channels
+    - command: /hearts-reset
+      url: https://hearts.mirror.zaratan.world/slack/events
+      description: Reset hearts for all residents
 oauth_config:
   redirect_urls:
     - https://hearts.mirror.zaratan.world/slack/oauth_redirect

--- a/src/bolt/hearts.app.js
+++ b/src/bolt/hearts.app.js
@@ -70,6 +70,9 @@ async function houseActive (houseId, now) {
 // Event listeners
 
 app.event('app_uninstalled', async ({ context }) => {
+  const [ now, houseId ] = [ new Date(), context.teamId ];
+
+  await Hearts.resetResidents(houseId, now);
   await common.uninstallApp(app, 'hearts', context);
 });
 

--- a/src/bolt/hearts.app.js
+++ b/src/bolt/hearts.app.js
@@ -207,6 +207,31 @@ app.command('/hearts-channel', async ({ ack, command, respond }) => {
   await common.setChannel(app, heartsConf.oauth, HEARTS_CONF, command, respond);
 });
 
+app.command('/hearts-reset', async ({ ack, command, respond }) => {
+  await ack();
+
+  const commandName = '/hearts-reset';
+  common.beginCommand(commandName, command);
+
+  if (!(await common.isAdmin(app, heartsConf.oauth, command.user_id))) {
+    await respond({ response_type: 'ephemeral', text: common.ADMIN_ONLY });
+  } else {
+    const view = views.heartsResetView();
+    await common.openView(app, heartsConf.oauth, command.trigger_id, view);
+  }
+});
+
+app.view('hearts-reset-callback', async ({ ack, body }) => {
+  await ack();
+
+  const actionName = 'hearts-reset-callback';
+  const { now, houseId, residentId } = common.beginAction(actionName, body);
+
+  await Hearts.resetResidents(houseId, now);
+
+  await postMessage(`<@${residentId}> just reset all hearts :heartpulse:`);
+});
+
 // Challenge flow
 
 app.action('hearts-challenge', async ({ ack, body }) => {

--- a/src/bolt/hearts.views.js
+++ b/src/bolt/hearts.views.js
@@ -83,6 +83,28 @@ exports.heartsHomeView = function (heartsChannel, isActive, numHearts, maxHearts
   };
 };
 
+// Slash commands
+
+exports.heartsResetView = function () {
+  const header = 'Reset hearts';
+  const mainText = 'Reset hearts for the workspace. ' +
+  'All hearts will be reset to 5.\n\n' +
+  ':warning: *This action cannot be undone!* :warning:';
+
+  const blocks = [];
+  blocks.push(common.blockHeader(header));
+  blocks.push(common.blockSection(mainText));
+
+  return {
+    type: 'modal',
+    callback_id: 'hearts-reset-callback',
+    title: TITLE,
+    close: common.CLOSE,
+    submit: common.SUBMIT,
+    blocks,
+  };
+};
+
 // Challenge flow
 
 exports.heartsChallengeView = function (numResidents) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -15,6 +15,7 @@ exports.HEART_CHALLENGE = 2;
 exports.HEART_KARMA = 3;
 exports.HEART_CHORE = 4;
 exports.HEART_REVIVE = 5;
+exports.HEART_RESET = 6;
 
 exports.CHORES_CONF = 'choresConf';
 exports.HEARTS_CONF = 'heartsConf';

--- a/src/core/hearts.js
+++ b/src/core/hearts.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 const { db } = require('./db');
 
 const { getMonthStart, getPrevMonthEnd } = require('../utils');
-const { HEART_REGEN, HEART_CHALLENGE, HEART_KARMA, HEART_REVIVE } = require('../constants');
+const { HEART_REGEN, HEART_CHALLENGE, HEART_KARMA, HEART_REVIVE, HEART_RESET } = require('../constants');
 
 const {
   heartsMinPctInitial,
@@ -85,6 +85,18 @@ exports.reviveResidents = async function (houseId, now) {
     .map(resident => exports.reviveResident(houseId, resident.slackId, now));
 
   return (await Promise.all(revivedResidents)).flat();
+};
+
+exports.resetResident = async function (houseId, residentId, now) {
+  const hearts = await exports.getHearts(residentId, now);
+  return exports.generateHearts(houseId, residentId, HEART_RESET, now, heartsBaselineAmount - hearts);
+};
+
+exports.resetResidents = async function (houseId, now) {
+  const resetResidents = (await Admin.getResidents(houseId, now))
+    .map(resident => exports.resetResident(houseId, resident.slackId, now));
+
+  return (await Promise.all(resetResidents)).flat();
 };
 
 exports.regenerateHearts = async function (houseId, residentId, now) {

--- a/test/hearts.test.js
+++ b/test/hearts.test.js
@@ -158,6 +158,16 @@ describe('Hearts', async () => {
       expect(hearts).to.equal(heartsReviveAmount);
     });
 
+    it('can reset a resident', async () => {
+      await Hearts.initialiseResident(HOUSE, RESIDENT1, now);
+
+      await Hearts.generateHearts(HOUSE, RESIDENT1, HEART_UNKNOWN, now, -2);
+      await Hearts.resetResident(HOUSE, RESIDENT1, now);
+
+      const hearts = await Hearts.getHearts(RESIDENT1, now);
+      expect(hearts).to.equal(heartsBaselineAmount);
+    });
+
     it('can check if a house is active using hearts', async () => {
       const nextWeek = new Date(now.getTime() + 7 * DAY);
 


### PR DESCRIPTION
Closes #220 

Adds the `Hearts.resetResidents` function and the `/hearts-reset` slash command. Also calls `resetResidents` as part of the Hearts uninstall flow.

Todo: consider limiting the `reset` commands to workspace owners only.