### PR TITLE
Improve private channel UX

### DIFF
--- a/src/bolt/chores.app.js
+++ b/src/bolt/chores.app.js
@@ -30,9 +30,11 @@ const app = new App({
   scopes: [
     'channels:history',
     'channels:join',
+    'channels:read',
     'chat:write',
     'commands',
     'groups:history',
+    'groups:read',
     'users:read',
   ],
   installationStore: {


### PR DESCRIPTION
We've had more than one community stumble in their onboarding by trying to use a private channel for app events (see #239).

The underlying issue is that Slack won't let you automatically add yourself to a private channel, and so using a private channel involves a two-step flow of first adding the app manually (`@Chores`) and then calling `/chores-channel`.

While the docs communicate this, the experience is still easy to fumble, putting new users in the awkward situation of having an "unlocked" app home page but seeing errors when trying to take any actions, with no obvious way to fix it.

This PR makes the process more robust by re-organizing the `setChannel` flow to:

1. Check to see if the app is _already_ a member of the channel
2. If not, attempt to add them
3. Only once the bot has been confirmed in a channel (either public or private) does the channel get saved

This flow (plus more extensive error-handling) will make it harder for new communities to set a channel without the app being able to post events. One downside is that we have to add **two new scopes** for all the apps -- `channels:read` and `groups:read` to be able to check if the app is already a member. 