### PR TITLE
Retire residents instead of reviving

### DIFF
--- a/src/bolt/hearts.app.js
+++ b/src/bolt/hearts.app.js
@@ -172,10 +172,9 @@ app.event('app_home_opened', async ({ body, event }) => {
     await postMessage(text);
   }
 
-  // Revive any residents
-  for (const revivalHeart of (await Hearts.reviveResidents(houseId, now))) {
-    const text = `Hello <!here>! *<@${revivalHeart.residentId}> lost all their hearts*, ` +
-      'and has been revived to three. :fairy:';
+  // Retire any residents
+  for (const residentId of (await Hearts.retireResidents(houseId, now))) {
+    const text = `*<@${residentId}> lost all their hearts* and is deactivated. :sleeping:`;
     await postMessage(text);
   }
 });

--- a/src/config.js
+++ b/src/config.js
@@ -27,7 +27,6 @@ exports.choreSpecialPctMax = 0.6; // Maximum threshold for special chores
 // Hearts
 exports.heartsPollLength = 3 * DAY;
 exports.heartsBaselineAmount = 5;
-exports.heartsReviveAmount = 3;
 exports.heartsRegenAmount = 0.25;
 exports.heartsFadeAmount = 0.25;
 exports.heartsMinPctInitial = 0.4; // For removing initial hearts

--- a/test/admin.test.js
+++ b/test/admin.test.js
@@ -153,7 +153,7 @@ describe('Admin', async () => {
       expect(residents.length).to.equal(0);
 
       const resident = await Admin.getResident(RESIDENT1);
-      expect(resident.activeAt).to.equal(null);
+      expect(resident.activeAt).to.be.null;
     });
 
     it('can return inactive for a non-existent resident', async () => {

--- a/test/chores.test.js
+++ b/test/chores.test.js
@@ -883,7 +883,7 @@ describe('Chores', async () => {
       // This claim was not resolved as poll is not yet closed
       const resolvedClaim3 = await Chores.getChoreClaim(choreClaim3.id);
       expect(resolvedClaim3.valid).to.be.true;
-      expect(resolvedClaim3.resolvedAt).to.equal(null);
+      expect(resolvedClaim3.resolvedAt).to.be.null;
     });
 
     it('cannot resolve a claim before the poll closes ', async () => {

--- a/test/things.test.js
+++ b/test/things.test.js
@@ -270,7 +270,7 @@ describe('Things', async () => {
       // This buy was not resolved as poll is not yet closed
       const resolvedBuy3 = await Things.getThingBuy(thingBuy3.id);
       expect(resolvedBuy3.valid).to.be.true;
-      expect(resolvedBuy3.resolvedAt).to.equal(null);
+      expect(resolvedBuy3.resolvedAt).to.be.null;
     });
 
     it('can get a list of unfulfilled buys', async () => {


### PR DESCRIPTION
Closes #269 

Currently, residents are automatically "revived" to 3 hearts after running out. This creates challenges in more casual settings like online communities, in which there are fewer built-in incentives for participation -- participants are more likely to churn, leading to many non-participating members who remain active and generating points. This creates significant "points inflation" and disrupts the mechanisms for everybody else.

This PR deactivates residents who run out of hearts, requiring explicit opt-in for them to be reactivated in the future. This means that non-participating members will be automatically pruned from the system, limiting their ability to inflate the points supply.

Implementation note: if a resident is reactivated after losing all their hearts, they will be reset to 5.