### PR TITLE
feat(chores): allow scheduling special chores

### DIFF
--- a/.manifest/chores-dev.yaml
+++ b/.manifest/chores-dev.yaml
@@ -23,6 +23,10 @@ features:
       url: https://zaratan.ngrok.io/slack/events
       description: Show more details about monthly chores
       should_escape: false
+    - command: /chores-special
+      url: https://zaratan.ngrok.io/slack/events
+      description: View current and upcoming special chores
+      should_escape: false
     - command: /chores-activate
       url: https://zaratan.ngrok.io/slack/events
       description: Activate residents for chores

--- a/.manifest/chores.yaml
+++ b/.manifest/chores.yaml
@@ -23,6 +23,10 @@ features:
       url: https://chores.mirror.zaratan.world/slack/events
       description: Show more details about monthly chores
       should_escape: false
+    - command: /chores-special
+      url: https://chores.mirror.zaratan.world/slack/events
+      description: View current and upcoming special chores
+      should_escape: false
     - command: /chores-activate
       url: https://chores.mirror.zaratan.world/slack/events
       description: Activate residents for chores

--- a/src/bolt/chores/handlers/commands.js
+++ b/src/bolt/chores/handlers/commands.js
@@ -47,6 +47,20 @@ module.exports = (app) => {
     await common.openView(app, choresConf.oauth, command.trigger_id, view);
   });
 
+  // Slash command: /chores-special
+  app.command('/chores-special', async ({ ack, command }) => {
+    await ack();
+
+    const { now, houseId } = common.beginCommand('/chores-special', command);
+    const { choresConf } = await Admin.getHouse(houseId);
+
+    const currentSpecialChores = await Chores.getUnclaimedSpecialChoreValues(houseId, now);
+    const futureSpecialChores = await Chores.getFutureSpecialChoreValues(houseId, now);
+
+    const view = views.choresSpecialListView(currentSpecialChores, futureSpecialChores);
+    await common.openView(app, choresConf.oauth, command.trigger_id, view);
+  });
+
   // Slash command: /chores-activate
   app.command('/chores-activate', async ({ ack, command, respond }) => {
     await ack();

--- a/src/bolt/chores/views/actions.js
+++ b/src/bolt/chores/views/actions.js
@@ -260,8 +260,8 @@ exports.choresRankView = function (choreRankings) {
 exports.choresRankView2 = function (preference, targetChore, choreRankings) {
   const header = 'Set chore priorities';
   const mainText = 'Priority-setting is a *collaborative and ongoing* process, ' +
-    'where people "take" priority from some chores and give it to others.\n\n' +
-    '*Example:* "I want to _prioritize_ dishes and _deprioritize_ yardwork."\n\n' +
+    'where you "take" priority from some chores and give it to others, ' +
+    'e.g. "I want to _prioritize_ dishes and _deprioritize_ yardwork."\n\n' +
     'To have a *bigger effect,* you can: ' +
     '*1)* take from *more* chores, ' +
     '*2)* take from *higher-priority* chores, ' +
@@ -280,7 +280,7 @@ exports.choresRankView2 = function (preference, targetChore, choreRankings) {
     {
       action_id: 'chores',
       type: 'multi_static_select',
-      placeholder: common.blockPlaintext('Choose some chores'),
+      placeholder: common.blockPlaintext('Choose one or more chores'),
       options: mapChoreRankings(choreRankings),
     },
   ));
@@ -349,9 +349,7 @@ exports.choresRankViewZero = function (preference) {
 
 // Break flow
 
-exports.choresBreakView = function (currentTime) {
-  const formattedTime = `${currentTime.getFullYear()}-${currentTime.getMonth() + 1}-${currentTime.getDate()}`;
-
+exports.choresBreakView = function (now) {
   const header = 'Take a break';
   const mainText = 'Take a chore break when you go out of town, ' +
     'and you won\'t owe points for the days that you\'re gone.\n\n' +
@@ -365,7 +363,7 @@ exports.choresBreakView = function (currentTime) {
     {
       action_id: 'date',
       type: 'datepicker',
-      initial_date: formattedTime,
+      initial_date: common.formatDate(now),
       placeholder: common.blockPlaintext('Select a date'),
     },
   ));
@@ -374,7 +372,7 @@ exports.choresBreakView = function (currentTime) {
     {
       action_id: 'date',
       type: 'datepicker',
-      initial_date: formattedTime,
+      initial_date: common.formatDate(now),
       placeholder: common.blockPlaintext('Select a date'),
     },
   ));
@@ -399,10 +397,10 @@ exports.choresBreakView = function (currentTime) {
 
 // Gift flow
 
-exports.choresGiftView = function (currentBalance) {
+exports.choresGiftView = function (balance) {
   const header = 'Gift chore points';
   const mainText = 'Gift someone points from your balance. ' +
-    `You have *${currentBalance} points* to gift.`;
+    `You have *${balance} points* to gift.`;
 
   const blocks = [];
   blocks.push(common.blockHeader(header));
@@ -438,7 +436,7 @@ exports.choresGiftView = function (currentBalance) {
   return {
     type: 'modal',
     callback_id: 'chores-gift-callback',
-    private_metadata: currentBalance.toString(),
+    private_metadata: balance.toString(),
     title: TITLE,
     close: common.CLOSE,
     submit: common.SUBMIT,
@@ -660,10 +658,9 @@ exports.choresProposeCallbackViewForce = function (metadata, residentId, name, d
 exports.choresSpecialView = function (minVotes, remainder) {
   const header = 'Add special chore';
   const mainText = 'Sometimes there are big one-off tasks that need to be done. ' +
-    'These can be seen as *special chores*.\n\n' +
+    'We call these *special chores*. ' +
     `Creating special chores requires *one upvote per 10 points*, and a *minimum of ${minVotes} upvotes*.`;
-  const remainderText = `There are *${remainder.toFixed(0)} free points* left for special chores this month. ` +
-    'Past this limit, everyone will owe extra points.';
+  const remainderText = `There are *${remainder.toFixed(0)} free points* left for special chores this month.`;
 
   const blocks = [];
   blocks.push(common.blockHeader(header));
@@ -678,6 +675,16 @@ exports.choresSpecialView = function (minVotes, remainder) {
       placeholder: common.blockPlaintext('Name of the chore'),
     },
   ));
+  blocks.push(common.blockInput(
+    'Points',
+    {
+      action_id: 'points',
+      type: 'number_input',
+      min_value: '1',
+      is_decimal_allowed: false,
+      placeholder: common.blockPlaintext('Number of points the chore is worth'),
+    },
+  ));
   blocks.push(common.blockInputOptional(
     'Description',
     {
@@ -688,14 +695,12 @@ exports.choresSpecialView = function (minVotes, remainder) {
       placeholder: common.blockPlaintext('Describe the chore (bullet points work well)'),
     },
   ));
-  blocks.push(common.blockInput(
-    'Points',
+  blocks.push(common.blockInputOptional(
+    'Claimable',
     {
-      action_id: 'points',
-      type: 'number_input',
-      min_value: '1',
-      is_decimal_allowed: false,
-      placeholder: common.blockPlaintext('Number of points the chore is worth'),
+      action_id: 'claimable',
+      type: 'datepicker',
+      placeholder: common.blockPlaintext('When the chore is available to claim'),
     },
   ));
 
@@ -712,8 +717,8 @@ exports.choresSpecialView = function (minVotes, remainder) {
 exports.choresSpecialCallbackView = function (proposal, minVotes, obligation) {
   const mainText = `*<@${proposal.proposedBy}>* wants to create a *special chore* ` +
     `worth *${proposal.metadata.value} points*:`;
-  const obligationText = 'Creating this special chore will add ' +
-    `*~${obligation.toFixed(0)} points* to everyone's requirement :bangbang:`;
+  const obligationText = 'By creating this special chore, ' +
+    `everyone will owe *~${obligation.toFixed(0)} extra points.*`;
 
   const blocks = [];
   blocks.push(common.blockSection(mainText));

--- a/src/bolt/chores/views/commands.js
+++ b/src/bolt/chores/views/commands.js
@@ -8,15 +8,18 @@ exports.choresStatsView = function (choreClaims, choreBreaks, choreStats) {
   const mainText = 'Extra information about monthly chores.';
 
   const claimText = '*Your claimed chores:*\n' +
-  choreClaims.map(cc => `\n${cc.claimedAt.toDateString()} - ${cc.name} - ${cc.value} points`)
-    .join('');
+    choreClaims
+      .map(cc => `\n${cc.claimedAt.toDateString()} - ${cc.name} - ${cc.value} points`)
+      .join('');
 
   const breakText = '*Current chore breaks:*\n' +
-    choreBreaks.map(cb => `\n${cb.startDate.toDateString()} - ${cb.endDate.toDateString()} - <@${cb.residentId}>`)
+    choreBreaks
+      .map(cb => `\n${cb.startDate.toDateString()} - ${cb.endDate.toDateString()} - <@${cb.residentId}>`)
       .join('');
 
   const pointsText = '*Last month\'s chore points:*\n' +
-    choreStats.map(cs => `\n${formatStats(cs)}`)
+    choreStats
+      .map(cs => `\n${formatStats(cs)}`)
       .join('');
 
   const blocks = [];
@@ -26,6 +29,39 @@ exports.choresStatsView = function (choreClaims, choreBreaks, choreStats) {
   blocks.push(common.blockSection(claimText));
   blocks.push(common.blockSection(breakText));
   blocks.push(common.blockSection(pointsText));
+
+  return {
+    type: 'modal',
+    title: TITLE,
+    close: common.CLOSE,
+    blocks,
+  };
+};
+
+exports.choresSpecialListView = function (currentChores, futureChores) {
+  const header = 'Special Chores';
+
+  const currentText = '*Current*\n' +
+    (currentChores.length > 0
+      ? currentChores
+        .map(cv => `\n${cv.metadata.name} - ${cv.value} points`)
+        .join('')
+      : '\n_No special chores available_'
+    );
+
+  const futureText = '*Future*\n' +
+    (futureChores.length > 0
+      ? futureChores
+        .map(cv => `\n${cv.metadata.name} - ${cv.value} points - ${common.formatDate(cv.valuedAt)}`)
+        .join('')
+      : '\n_No upcoming special chores_'
+    );
+
+  const blocks = [];
+  blocks.push(common.blockHeader(header));
+  blocks.push(common.blockDivider());
+  blocks.push(common.blockSection(currentText));
+  blocks.push(common.blockSection(futureText));
 
   return {
     type: 'modal',

--- a/src/bolt/chores/views/events.js
+++ b/src/bolt/chores/views/events.js
@@ -52,9 +52,9 @@ exports.choresHomeView = function (choreChannel, choreStats, numActive) {
     if (Number(pointsEarned) < Number(pointsOwed) + Chores.params.pointsBuffer) {
       actions.push(common.blockButton('chores-claim', ':hand::skin-tone-4: Claim a chore'));
     }
+    actions.push(common.blockButton('chores-rank', ':scales: Set priorities'));
     actions.push(common.blockButton('chores-break', ':camping: Take a break'));
     actions.push(common.blockButton('chores-gift', ':gift: Gift your points'));
-    actions.push(common.blockButton('chores-rank', ':scales: Set priorities'));
     actions.push(common.blockButton('chores-special', ':bulb: Add special chore'));
     actions.push(common.blockButton('chores-propose', ':notebook: Edit chores list'));
   } else {

--- a/src/bolt/common.js
+++ b/src/bolt/common.js
@@ -44,6 +44,10 @@ exports.parseUrl = function (url) {
   } catch {}
 };
 
+exports.formatDate = function (date) {
+  return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+};
+
 // Installation store factory
 
 exports.createInstallationStore = function (confName, appName) {

--- a/test/chores.test.js
+++ b/test/chores.test.js
@@ -1649,7 +1649,6 @@ describe('Chores', async () => {
 
       await Polls.submitVote(proposal.pollId, RESIDENT1, now, Polls.YAY);
       await Polls.submitVote(proposal.pollId, RESIDENT2, now, Polls.YAY);
-
       await Chores.resolveChoreProposal(proposal.id, proposalEnd);
 
       chores = await Chores.getChores(HOUSE);
@@ -1670,7 +1669,6 @@ describe('Chores', async () => {
 
       await Polls.submitVote(proposal.pollId, RESIDENT1, now, Polls.YAY);
       await Polls.submitVote(proposal.pollId, RESIDENT2, now, Polls.YAY);
-
       await Chores.resolveChoreProposal(proposal.id, proposalEnd);
 
       chores = await Chores.getChores(HOUSE);
@@ -1683,7 +1681,6 @@ describe('Chores', async () => {
 
       await Polls.submitVote(proposal.pollId, RESIDENT1, now, Polls.YAY);
       await Polls.submitVote(proposal.pollId, RESIDENT2, now, Polls.YAY);
-
       await Chores.resolveChoreProposal(proposal.id, proposalEnd);
       chores = await Chores.getChores(HOUSE);
       expect(chores.length).to.equal(1);
@@ -1698,7 +1695,6 @@ describe('Chores', async () => {
 
       await Polls.submitVote(proposal.pollId, RESIDENT1, now, Polls.YAY);
       await Polls.submitVote(proposal.pollId, RESIDENT2, now, Polls.YAY);
-
       await Chores.resolveChoreProposal(proposal.id, proposalEnd);
 
       chores = await Chores.getChores(HOUSE);
@@ -1712,7 +1708,6 @@ describe('Chores', async () => {
 
       await Polls.submitVote(proposal.pollId, RESIDENT1, now, Polls.YAY);
       await Polls.submitVote(proposal.pollId, RESIDENT2, now, Polls.YAY);
-
       await Chores.resolveChoreProposal(proposal.id, proposalEnd);
 
       chores = await Chores.getChores(HOUSE);
@@ -1727,7 +1722,6 @@ describe('Chores', async () => {
 
       await Polls.submitVote(proposal.pollId, RESIDENT1, now, Polls.YAY);
       await Polls.submitVote(proposal.pollId, RESIDENT2, now, Polls.YAY);
-
       await Chores.resolveChoreProposal(proposal.id, proposalEnd);
 
       chores = await Chores.getChores(HOUSE);
@@ -1737,7 +1731,6 @@ describe('Chores', async () => {
 
       await Polls.submitVote(proposal.pollId, RESIDENT1, now, Polls.YAY);
       await Polls.submitVote(proposal.pollId, RESIDENT2, now, Polls.YAY);
-
       await Chores.resolveChoreProposal(proposal.id, proposalEnd);
 
       chores = await Chores.getChores(HOUSE);
@@ -1757,17 +1750,44 @@ describe('Chores', async () => {
       [ choreValue ] = await Chores.getUnclaimedSpecialChoreValues(HOUSE, now);
       expect(choreValue).to.be.undefined;
 
-      const [ proposal ] = await Chores.createSpecialChoreProposal(HOUSE, RESIDENT1, name, description, value, now);
+      const [ proposal ] = await Chores.createSpecialChoreProposal(HOUSE, RESIDENT1, name, description, value, now, now);
 
       await Polls.submitVote(proposal.pollId, RESIDENT1, now, Polls.YAY);
       await Polls.submitVote(proposal.pollId, RESIDENT2, now, Polls.YAY);
-
       await Chores.resolveChoreProposal(proposal.id, specialChoreProposalEnd);
 
       [ choreValue ] = await Chores.getUnclaimedSpecialChoreValues(HOUSE, specialChoreProposalEnd);
       expect(choreValue.metadata.name).to.equal(name);
       expect(choreValue.metadata.description).to.equal(description);
       expect(choreValue.value).to.equal(value);
+    });
+
+    it('can create a special chore proposal claimable in the future', async () => {
+      const [ name, description, value ] = [ 'Future Chore', 'Important annual task', 50 ];
+
+      let currentChores;
+      let futureChores;
+
+      currentChores = await Chores.getUnclaimedSpecialChoreValues(HOUSE, now);
+      futureChores = await Chores.getFutureSpecialChoreValues(HOUSE, now);
+      expect(currentChores).to.have.length(0);
+      expect(futureChores).to.have.length(0);
+
+      const [ proposal ] = await Chores.createSpecialChoreProposal(HOUSE, RESIDENT1, name, description, value, tomorrow, now);
+
+      await Polls.submitVote(proposal.pollId, RESIDENT1, now, Polls.YAY);
+      await Polls.submitVote(proposal.pollId, RESIDENT2, now, Polls.YAY);
+      await Chores.resolveChoreProposal(proposal.id, specialChoreProposalEnd);
+
+      currentChores = await Chores.getUnclaimedSpecialChoreValues(HOUSE, soon);
+      futureChores = await Chores.getFutureSpecialChoreValues(HOUSE, soon);
+      expect(currentChores).to.have.length(0);
+      expect(futureChores).to.have.length(1);
+
+      currentChores = await Chores.getUnclaimedSpecialChoreValues(HOUSE, tomorrow);
+      futureChores = await Chores.getFutureSpecialChoreValues(HOUSE, tomorrow);
+      expect(currentChores).to.have.length(1);
+      expect(futureChores).to.have.length(0);
     });
 
     it('can return the minimum votes for a special chore proposal', async () => {


### PR DESCRIPTION
The folks at Solegria have asked for special chores to be schedulable in advance, so that they can set up a years worth of tasks at once without having them be front-loaded in the accounting.

Conveniently, the current implementation can be trivially extended, by setting the `valuedAt` date to a point in the future.

This PR:

- Adds an optional "Claimable" field to the special chores creation flow.
- Sets the `valuedAt` property to the claimable date, if provided, or else to the current time.
- Adds a `/chores-special` command to show a modal of current and future special chores.