### PR TITLE
feat: revise /chore-stats view

### DIFF
--- a/src/bolt/chores/handlers/commands.js
+++ b/src/bolt/chores/handlers/commands.js
@@ -1,5 +1,5 @@
 const { Admin, Chores } = require('../../../core/index');
-const { getMonthStart, getPrevMonthEnd } = require('../../../time');
+const { getMonthStart } = require('../../../time');
 
 const common = require('../../common');
 const views = require('../views/commands');
@@ -36,16 +36,13 @@ module.exports = (app) => {
     const { choresConf } = await Admin.getHouse(houseId);
 
     const monthStart = getMonthStart(now);
-    const prevMonthEnd = getPrevMonthEnd(now);
-    const prevMonthStart = getMonthStart(prevMonthEnd);
-
-    // TODO: Calculate remaining points in the month
 
     const choreClaims = await Chores.getChoreClaims(residentId, monthStart, now);
     const choreBreaks = await Chores.getChoreBreaks(houseId, now);
-    const choreStats = await Chores.getHouseChoreStats(houseId, prevMonthStart, prevMonthEnd);
+    const choreStats = await Chores.getHouseChoreStats(houseId, monthStart, now);
+    const choreValues = await Chores.getCurrentChoreValues(houseId, now);
 
-    const view = views.choresStatsView(choreClaims, choreBreaks, choreStats);
+    const view = views.choresStatsView(choreClaims, choreBreaks, choreStats, choreValues);
     await common.openView(app, choresConf.oauth, command.trigger_id, view);
   });
 

--- a/src/bolt/chores/views/commands.js
+++ b/src/bolt/chores/views/commands.js
@@ -1,34 +1,51 @@
 const common = require('../../common');
-const { TITLE, formatStats } = require('./utils');
+const { TITLE, formatStats, formatTotalStats } = require('./utils');
 
 // Command views
 
-exports.choresStatsView = function (choreClaims, choreBreaks, choreStats) {
+exports.choresStatsView = function (choreClaims, choreBreaks, choreStats, choreValues) {
   const header = 'See chore stats';
-  const mainText = 'Extra information about monthly chores.';
 
-  const claimText = '*Your claimed chores:*\n' +
-    choreClaims
-      .map(cc => `\n${cc.claimedAt.toDateString()} - ${cc.name} - ${cc.value} points`)
-      .join('');
+  const availablePoints = choreValues.reduce((sum, cv) => sum + cv.value, 0);
+  const availableText = `*Points available to claim:* ${availablePoints.toFixed(0)}`;
 
-  const breakText = '*Current chore breaks:*\n' +
-    choreBreaks
-      .map(cb => `\n${cb.startDate.toDateString()} - ${cb.endDate.toDateString()} - <@${cb.residentId}>`)
-      .join('');
+  const totalSpecialObligation = choreStats.length
+    ? choreStats[0].specialObligation * choreStats.length
+    : 0;
+  const specialNote = totalSpecialObligation > 0
+    ? `\n_Includes ${totalSpecialObligation.toFixed(0)} points of special chores_`
+    : '';
 
-  const pointsText = '*Last month\'s chore points:*\n' +
-    choreStats
-      .map(cs => `\n${formatStats(cs)}`)
-      .join('');
+  const statsText = '*Current points:*\n' +
+    (choreStats.length > 0
+      ? choreStats
+        .map(cs => `\n${formatStats(cs)}`)
+        .join('') + `\n\n${formatTotalStats(choreStats)}${specialNote}`
+      : '\n_No active residents_'
+    );
+
+  const claimText = '*Your claims:*\n' +
+    (choreClaims.length > 0
+      ? choreClaims
+        .map(cc => `\n${cc.claimedAt.toDateString()} - ${cc.name} - ${cc.value} points`)
+        .join('')
+      : '\n_No claims yet_'
+    );
+
+  const breakText = '*Current breaks:*\n' +
+    (choreBreaks.length > 0
+      ? choreBreaks
+        .map(cb => `\n${cb.startDate.toDateString()} - ${cb.endDate.toDateString()} - <@${cb.residentId}>`)
+        .join('')
+      : '\n_No one is on break_'
+    );
 
   const blocks = [];
   blocks.push(common.blockHeader(header));
-  blocks.push(common.blockSection(mainText));
-  blocks.push(common.blockDivider());
+  blocks.push(common.blockSection(availableText));
+  blocks.push(common.blockSection(statsText));
   blocks.push(common.blockSection(claimText));
   blocks.push(common.blockSection(breakText));
-  blocks.push(common.blockSection(pointsText));
 
   return {
     type: 'modal',

--- a/src/bolt/chores/views/utils.js
+++ b/src/bolt/chores/views/utils.js
@@ -10,7 +10,7 @@ exports.DOCS_URL = 'https://docs.chorewheel.zaratan.world/en/latest/tools/chores
 // Formatting functions
 
 exports.formatStats = function (stats) {
-  const { residentId, pointsEarned, pointsOwed, completionPct } = stats;
+  const { residentId, pointsEarned, pointsOwed, completionPct, workingPercentage } = stats;
 
   let emoji = '';
   if (pointsEarned >= pointsOwed) {
@@ -19,13 +19,18 @@ exports.formatStats = function (stats) {
     emoji = ':broken_heart:';
   }
 
-  return `<@${residentId}> - ${pointsEarned} / ${pointsOwed} (${(completionPct * 100).toFixed(0)}%) ${emoji}`;
+  let breakTag = '';
+  if (workingPercentage !== undefined && workingPercentage < 1) {
+    breakTag = ` :palm_tree: -${((1 - workingPercentage) * 100).toFixed(0)}%`;
+  }
+
+  return `${emoji} <@${residentId}> - ${pointsEarned} / ${pointsOwed} (${(completionPct * 100).toFixed(0)}%)${breakTag}`;
 };
 
 exports.formatTotalStats = function (stats) {
   const pointsEarned = stats.reduce((sum, stat) => sum + stat.pointsEarned, 0);
   const pointsOwed = stats.reduce((sum, stat) => sum + stat.pointsOwed, 0);
-  const completionPct = pointsEarned / pointsOwed;
+  const completionPct = pointsOwed ? pointsEarned / pointsOwed : 1;
 
   return `*Total - ${pointsEarned} / ${pointsOwed} (${(completionPct * 100).toFixed(0)}%)*`;
 };

--- a/src/core/chores.js
+++ b/src/core/chores.js
@@ -747,7 +747,7 @@ exports.getChoreStats = async function (houseId, residentId, startTime, endTime)
   const pointsOwed = Math.round((residentObligation + specialObligation) * workingPercentage);
   const completionPct = (pointsOwed) ? pointsEarned / pointsOwed : 1;
 
-  return { pointsEarned, pointsOwed, completionPct };
+  return { pointsEarned, pointsOwed, completionPct, workingPercentage, specialObligation };
 };
 
 exports.getHouseChoreStats = async function (houseId, startTime, endTime) {

--- a/test/chores.test.js
+++ b/test/chores.test.js
@@ -1198,6 +1198,8 @@ describe('Chores', async () => {
       expect(choreStats.pointsEarned).to.equal(11);
       expect(choreStats.pointsOwed).to.equal(100);
       expect(choreStats.completionPct).to.equal(0.11);
+      expect(choreStats.workingPercentage).to.equal(1);
+      expect(choreStats.specialObligation).to.equal(0);
 
       await Chores.addSpecialChoreValue(HOUSE, 'Special', '', 55, feb15);
 
@@ -1205,6 +1207,8 @@ describe('Chores', async () => {
       expect(choreStats.pointsEarned).to.equal(11);
       expect(choreStats.pointsOwed).to.equal(110); // Split among 4 residents
       expect(choreStats.completionPct).to.equal(0.1);
+      expect(choreStats.workingPercentage).to.equal(1);
+      expect(choreStats.specialObligation).to.equal(10);
 
       await Chores.addChoreBreak(HOUSE, RESIDENT1, feb1, mar1, '');
 
@@ -1212,6 +1216,7 @@ describe('Chores', async () => {
       expect(choreStats.pointsEarned).to.equal(11);
       expect(choreStats.pointsOwed).to.equal(0);
       expect(choreStats.completionPct).to.equal(1);
+      expect(choreStats.workingPercentage).to.equal(0);
     });
 
     it('can get resident chore stats with a custom obligation', async () => {


### PR DESCRIPTION
## Summary
- Switch `/chore-stats` from showing *last* month to *current* month, with a "Points available to claim" header and a per-resident totals row.
- Add a palm-tree tag to `formatStats` for residents on partial break (`workingPercentage < 1`).
- Surface `workingPercentage` and `specialObligation` from `getChoreStats`, and note any special-chore obligation included in the totals.
- Improve empty-state copy across stats / claims / breaks sections.

## Test plan
- [x] `pnpm test` (178 passing)
- [x] `pnpm run lint`
- [ ] Manual: open `/chore-stats` in a workspace and confirm available points, totals, special-chore note, and break tag render correctly