### PR TITLE
feat(chores): emphasize points-per-day in prioritization flow

### DIFF
--- a/src/bolt/chores/handlers/actions.js
+++ b/src/bolt/chores/handlers/actions.js
@@ -289,17 +289,17 @@ module.exports = (app) => {
     const newPriority = targetChoreRanking.ranking * 100;
     const totalObligation = await Chores.getTotalObligation(houseId, now);
 
-    const oldPointsPerDay = formatPointsPerDay(targetChore.ranking, totalObligation);
-    const newPointsPerDay = formatPointsPerDay(targetChoreRanking.ranking, totalObligation);
-    const change = newPointsPerDay - oldPointsPerDay;
+    const oldPpd = formatPointsPerDay(targetChore.ranking, totalObligation);
+    const newPpd = formatPointsPerDay(targetChoreRanking.ranking, totalObligation);
+    const change = newPpd - oldPpd;
 
     if (change > 0) {
-      const text = `Someone *prioritized ${targetChore.name}* to *${newPointsPerDay} points per day* ` +
-        `(+${change.toFixed(1)} ppd), or *${newPriority.toFixed(1)}%* of total points :rocket:`;
+      const text = `Someone *prioritized ${targetChore.name}* to *${newPpd} points per day* ` +
+        `(+${change.toFixed(1)} ppd), or *${newPriority.toFixed(1)}%* of all points :rocket:`;
       await common.postMessage(app, choresConf, text);
     } else if (change < 0) {
-      const text = `Someone *deprioritized ${targetChore.name}* to *${newPointsPerDay} points per day* ` +
-        `(${change.toFixed(1)} ppd), or *${newPriority.toFixed(1)}%* of total points :snail:`;
+      const text = `Someone *deprioritized ${targetChore.name}* to *${newPpd} points per day* ` +
+        `(${change.toFixed(1)} ppd), or *${newPriority.toFixed(1)}%* of all points :snail:`;
       await common.postMessage(app, choresConf, text);
     }
 

--- a/src/bolt/chores/handlers/actions.js
+++ b/src/bolt/chores/handlers/actions.js
@@ -100,8 +100,9 @@ module.exports = (app) => {
     const { choresConf } = await Admin.getHouse(houseId);
 
     const choreRankings = await Chores.getCurrentChoreRankings(houseId, now);
+    const totalObligation = await Chores.getTotalObligation(houseId, now);
 
-    const view = views.choresRankPreView(choreRankings);
+    const view = views.choresRankPreView(choreRankings, totalObligation);
     await common.openView(app, choresConf.oauth, body.trigger_id, view);
 
     await ack();
@@ -209,8 +210,9 @@ module.exports = (app) => {
     const { choresConf } = await Admin.getHouse(houseId);
 
     const choreRankings = await Chores.getCurrentChoreRankings(houseId, now);
+    const totalObligation = await Chores.getTotalObligation(houseId, now);
 
-    const view = views.choresRankView(choreRankings);
+    const view = views.choresRankView(choreRankings, totalObligation);
     await common.openView(app, choresConf.oauth, body.trigger_id, view);
 
     await ack();
@@ -233,8 +235,10 @@ module.exports = (app) => {
     const choreRankings = (await Chores.getCurrentChoreRankings(houseId, now))
       .filter(ranking => ranking.id !== targetChore.id && !sourceExclusionSet.has(ranking.id));
 
+    const totalObligation = await Chores.getTotalObligation(houseId, now);
+
     const view = (choreRankings.length)
-      ? views.choresRankView2(actionPreference, targetChore, choreRankings)
+      ? views.choresRankView2(actionPreference, targetChore, choreRankings, totalObligation)
       : views.choresRankViewZero(actionPreference);
 
     await ack({ response_action: 'push', view });
@@ -283,18 +287,19 @@ module.exports = (app) => {
     const targetChoreRanking = choreRankings.find(chore => chore.id === targetChore.id);
 
     const newPriority = targetChoreRanking.ranking * 100;
-    const change = newPriority - targetChore.priority;
-
     const totalObligation = await Chores.getTotalObligation(houseId, now);
-    const pointsPerDay = formatPointsPerDay(targetChoreRanking.ranking, totalObligation);
+
+    const oldPointsPerDay = formatPointsPerDay(targetChore.ranking, totalObligation);
+    const newPointsPerDay = formatPointsPerDay(targetChoreRanking.ranking, totalObligation);
+    const change = newPointsPerDay - oldPointsPerDay;
 
     if (change > 0) {
-      const text = `Someone *prioritized ${targetChore.name}* to *${newPriority.toFixed(1)}%* ` +
-        `(+${change.toFixed(1)}%), or about *${pointsPerDay} points per day* :rocket:`;
+      const text = `Someone *prioritized ${targetChore.name}* to *${newPointsPerDay} points per day* ` +
+        `(+${change.toFixed(1)} ppd), or *${newPriority.toFixed(1)}%* of total points :rocket:`;
       await common.postMessage(app, choresConf, text);
     } else if (change < 0) {
-      const text = `Someone *deprioritized ${targetChore.name}* to *${newPriority.toFixed(1)}%* ` +
-        `(${change.toFixed(1)}%), or about *${pointsPerDay} points per day* :snail:`;
+      const text = `Someone *deprioritized ${targetChore.name}* to *${newPointsPerDay} points per day* ` +
+        `(${change.toFixed(1)} ppd), or *${newPriority.toFixed(1)}%* of total points :snail:`;
       await common.postMessage(app, choresConf, text);
     }
 

--- a/src/bolt/chores/views/actions.js
+++ b/src/bolt/chores/views/actions.js
@@ -222,10 +222,10 @@ exports.choresClaimCallbackView = function (claim, name, minVotes, achivementPoi
 
 // Ranking flow
 
-exports.choresRankPreView = function (choreRankings) {
+exports.choresRankPreView = function (choreRankings, totalObligation) {
   const header = 'Preview priorities';
-  const mainText = 'These are the current chore priorities:\n\n' +
-    choreRankings.map(chore => `- ${chore.name} - ${(chore.ranking * 100).toFixed(1)}%`).join('\n');
+  const mainText = `These are the current chore priorities (about *${totalObligation} points per month* total):\n\n` +
+    choreRankings.map(chore => `- ${chore.name} - ${formatPointsPerDay(chore.ranking, totalObligation)} ppd`).join('\n');
 
   const blocks = [];
   blocks.push(common.blockHeader(header));
@@ -239,11 +239,12 @@ exports.choresRankPreView = function (choreRankings) {
   };
 };
 
-exports.choresRankView = function (choreRankings) {
+exports.choresRankView = function (choreRankings, totalObligation) {
   const header = 'Set chore priorities';
   const mainText = 'The higher a chore\'s priority, the more points it gets over time.\n\n' +
-    'Chore priorities are measured in *percentages*. ' +
-    'A chore with *0% priority* gets no points, while one with *100% priority* gets _all_ the points.';
+    'Chore priorities are measured in *points per day* (ppd). ' +
+    `The total number of points is fixed (about *${totalObligation} per month*), ` +
+    'so prioritizing one chore deprioritizes another.';
 
   const actions = [
     { value: String(1), text: common.blockPlaintext('prioritize (more points over time)') },
@@ -274,7 +275,7 @@ exports.choresRankView = function (choreRankings) {
       action_id: 'chore',
       type: 'static_select',
       placeholder: common.blockPlaintext('Choose a chore'),
-      options: mapChoreRankings(choreRankings),
+      options: mapChoreRankings(choreRankings, totalObligation),
     },
   ));
   blocks.push(common.blockInput(
@@ -296,7 +297,7 @@ exports.choresRankView = function (choreRankings) {
   };
 };
 
-exports.choresRankView2 = function (preference, targetChore, choreRankings) {
+exports.choresRankView2 = function (preference, targetChore, choreRankings, totalObligation) {
   const effect = (preference >= 0.5) ? 'prioritize' : 'deprioritize';
   const magnitude = Math.abs(preference - 0.5) > 0.2 ? 'a lot' : 'a little';
 
@@ -310,7 +311,7 @@ exports.choresRankView2 = function (preference, targetChore, choreRankings) {
     '*3)* set a *stronger* preference, or ' +
     '*4)* get *other people* to put in the same preferences.';
   const actionText = `You want to *${effect}* *${targetChore.name}* ` +
-    `(${targetChore.priority.toFixed(1)}%) by *${magnitude}*,`;
+    `(${formatPointsPerDay(targetChore.ranking, totalObligation)} ppd) by *${magnitude}*,`;
 
   const blocks = [];
   blocks.push(common.blockHeader(header));
@@ -323,7 +324,7 @@ exports.choresRankView2 = function (preference, targetChore, choreRankings) {
       action_id: 'chores',
       type: 'multi_static_select',
       placeholder: common.blockPlaintext('Choose one or more chores'),
-      options: mapChoreRankings(choreRankings),
+      options: mapChoreRankings(choreRankings, totalObligation),
     },
   ));
 
@@ -340,20 +341,20 @@ exports.choresRankView2 = function (preference, targetChore, choreRankings) {
 
 exports.choresRankView3 = function (targetChore, targetChoreRanking, prefsMetadata, prefSaturation, totalObligation) {
   const newPriority = targetChoreRanking.ranking * 100;
-  const change = newPriority - targetChore.priority;
-  const pointsPerDay = formatPointsPerDay(targetChoreRanking.ranking, totalObligation);
+  const oldPointsPerDay = formatPointsPerDay(targetChore.ranking, totalObligation);
+  const newPointsPerDay = formatPointsPerDay(targetChoreRanking.ranking, totalObligation);
+  const change = newPointsPerDay - oldPointsPerDay;
 
   const effect = change >= 0 ? 'an *increase*' : 'a *decrease*';
-  const emoji = change >= 0 ? ':rocket:' : ':snail:';
   const saturation = (change >= 0 ? prefSaturation : 1 - prefSaturation) * 100;
 
   const header = 'Set chore priorities';
   const priorityText = 'After your update, ' +
-      `*${targetChore.name}* will have a priority of *${newPriority.toFixed(1)}%*, ` +
-      `${effect} of *${Math.abs(change).toFixed(1)}%*. ` +
-      `That's about *${pointsPerDay} points per day* ${emoji}`;
-  const submitText = `Your preferences for *${targetChore.name}* are at *${saturation.toFixed(0)}%* of possible strength. ` +
-    '*Submit* to confirm, or go *back* to change your update.';
+      `*${targetChore.name}* will be worth *${newPointsPerDay} points per day*, ` +
+      `${effect} of *${Math.abs(change).toFixed(1)} ppd*. ` +
+      `That's *${newPriority.toFixed(1)}%* of total points.`;
+  const submitText = `Your personal preferences for *${targetChore.name}* are at *${saturation.toFixed(0)}%* of possible strength. ` +
+    '*Submit* to confirm, or go *back* to adjust your update.';
 
   const blocks = [];
   blocks.push(common.blockHeader(header));

--- a/src/bolt/chores/views/actions.js
+++ b/src/bolt/chores/views/actions.js
@@ -341,18 +341,18 @@ exports.choresRankView2 = function (preference, targetChore, choreRankings, tota
 
 exports.choresRankView3 = function (targetChore, targetChoreRanking, prefsMetadata, prefSaturation, totalObligation) {
   const newPriority = targetChoreRanking.ranking * 100;
-  const oldPointsPerDay = formatPointsPerDay(targetChore.ranking, totalObligation);
-  const newPointsPerDay = formatPointsPerDay(targetChoreRanking.ranking, totalObligation);
-  const change = newPointsPerDay - oldPointsPerDay;
+  const oldPpd = formatPointsPerDay(targetChore.ranking, totalObligation);
+  const newPpd = formatPointsPerDay(targetChoreRanking.ranking, totalObligation);
+  const change = newPpd - oldPpd;
 
   const effect = change >= 0 ? 'an *increase*' : 'a *decrease*';
   const saturation = (change >= 0 ? prefSaturation : 1 - prefSaturation) * 100;
 
   const header = 'Set chore priorities';
   const priorityText = 'After your update, ' +
-      `*${targetChore.name}* will be worth *${newPointsPerDay} points per day*, ` +
+      `*${targetChore.name}* will be worth *${newPpd} points per day*, ` +
       `${effect} of *${Math.abs(change).toFixed(1)} ppd*. ` +
-      `That's *${newPriority.toFixed(1)}%* of total points.`;
+      `That's *${newPriority.toFixed(1)}%* of all points.`;
   const submitText = `Your personal preferences for *${targetChore.name}* are at *${saturation.toFixed(0)}%* of possible strength. ` +
     '*Submit* to confirm, or go *back* to adjust your update.';
 

--- a/src/bolt/chores/views/utils.js
+++ b/src/bolt/chores/views/utils.js
@@ -36,8 +36,7 @@ exports.formatTotalStats = function (stats) {
 };
 
 exports.formatPointsPerDay = function (ranking, totalObligation) {
-  const pointsPerDay = ranking * totalObligation / 30;
-  return (pointsPerDay >= 3) ? pointsPerDay.toFixed(0) : pointsPerDay.toFixed(1);
+  return (ranking * totalObligation / 30).toFixed(1);
 };
 
 exports.getAchievement = function (totalPoints) {
@@ -79,13 +78,13 @@ exports.mapChoresValues = function (chores) {
   });
 };
 
-exports.mapChoreRankings = function (choreRankings) {
+exports.mapChoreRankings = function (choreRankings, totalObligation) {
   return choreRankings.map((chore) => {
-    const priority = chore.ranking * 100;
+    const pointsPerDay = exports.formatPointsPerDay(chore.ranking, totalObligation);
     return {
-      value: JSON.stringify({ id: chore.id, name: chore.name, priority }),
+      value: JSON.stringify({ id: chore.id, name: chore.name, ranking: chore.ranking }),
       // Max length is 75 chars, so we need to truncate the name
-      text: common.blockPlaintext(`${chore.name.slice(0, 60)} - ${priority.toFixed(1)}%`),
+      text: common.blockPlaintext(`${chore.name.slice(0, 60)} - ${pointsPerDay} ppd`),
     };
   });
 };

--- a/src/bolt/chores/views/utils.js
+++ b/src/bolt/chores/views/utils.js
@@ -80,11 +80,11 @@ exports.mapChoresValues = function (chores) {
 
 exports.mapChoreRankings = function (choreRankings, totalObligation) {
   return choreRankings.map((chore) => {
-    const pointsPerDay = exports.formatPointsPerDay(chore.ranking, totalObligation);
+    const ppd = exports.formatPointsPerDay(chore.ranking, totalObligation);
     return {
       value: JSON.stringify({ id: chore.id, name: chore.name, ranking: chore.ranking }),
       // Max length is 75 chars, so we need to truncate the name
-      text: common.blockPlaintext(`${chore.name.slice(0, 60)} - ${pointsPerDay} ppd`),
+      text: common.blockPlaintext(`${chore.name.slice(0, 60)} - ${ppd} ppd`),
     };
   });
 };


### PR DESCRIPTION
## Summary

- Flip ppd ↔ percentage in the priority-setting flow so points-per-day is the primary unit residents see when prioritizing chores. Percentage of total is still surfaced as secondary context on the confirmation screen and final channel post.
- Drop conditional whole-number rounding in \`formatPointsPerDay\` (always 1 decimal) so small priority shifts remain visible.
- Anchor the household's total monthly points in step 1 of the flow and in the read-only preview header, so ppd values have a frame of reference.

Motivated by resident feedback that ppd is the unit of account people actually care about (it's what they earn, what shows on stats); a 5% shift in share is harder to reason about than "this chore goes from 7 to 8 ppd."

## Test plan

- [x] \`pnpm run lint\` clean
- [x] \`pnpm test\` — all 178 tests pass (no core/algorithm changes)
- [ ] Manual smoke test in dev Slack workspace:
  - [x] \`:scales: Set priorities\` → step 1 intro shows ppd framing + monthly total; dropdown reads \`chore - X.X ppd\`
  - [x] Step 2 header reads \`dishes (X.X ppd) by a lot\`
  - [x] Confirmation screen leads with ppd, change in ppd, total % as secondary
  - [x] Channel post leads with ppd, change in ppd, total % as secondary
  - [ ] \`:eyes: View priorities\` preview shows monthly total + per-chore ppd

🤖 Generated with [Claude Code](https://claude.com/claude-code)