### PR TITLE
refactor: use optional chaining (#293)

### DIFF
--- a/src/bolt/chores/handlers/actions.js
+++ b/src/bolt/chores/handlers/actions.js
@@ -197,7 +197,7 @@ module.exports = (app) => {
     await Polls.updateMetadata(claim.pollId, { channel, ts });
 
     // Append the description
-    if (chore.metadata && chore.metadata.description) {
+    if (chore.metadata?.description) {
       const text = `*Description:*\n${chore.metadata.description}`;
       await common.postReply(app, choresConf, ts, text);
     }

--- a/src/bolt/common.js
+++ b/src/bolt/common.js
@@ -412,7 +412,7 @@ exports.makeForceInput = function () {
 
 // Block may or may not exist
 exports.getForceInput = function (block) {
-  if (block && block.force) {
+  if (block?.force) {
     return block.force.selected_option.value === 'true';
   } else {
     return false;

--- a/src/bolt/things/views/utils.js
+++ b/src/bolt/things/views/utils.js
@@ -22,7 +22,7 @@ exports.formatTypedThing = function (thing) {
 exports.formatBuy = function (buy, url = true) {
   let text;
 
-  if (buy.metadata && buy.metadata.special) {
+  if (buy.metadata?.special) {
     text = `Special: ${buy.metadata.title}`;
   } else if (buy.metadata && buy.thingMetadata) {
     text = `${buy.name} (${buy.metadata.quantity} x ${buy.thingMetadata.unit})`;
@@ -30,7 +30,7 @@ exports.formatBuy = function (buy, url = true) {
     text = `${buy.name} (?)`;
   }
 
-  if (url && buy.thingMetadata && buy.thingMetadata.url) {
+  if (url && buy.thingMetadata?.url) {
     text = `<${buy.thingMetadata.url}|${text}>`;
   }
 

--- a/src/core/admin.js
+++ b/src/core/admin.js
@@ -98,5 +98,5 @@ exports.getNumResidents = async function (houseId, now) {
 
 exports.isActive = async function (residentId, now) {
   const resident = await exports.getResident(residentId);
-  return (resident && resident.activeAt && resident.activeAt <= now);
+  return (resident?.activeAt && resident.activeAt <= now);
 };

--- a/src/core/chores.js
+++ b/src/core/chores.js
@@ -201,7 +201,7 @@ exports.getPreferenceSaturation = async function (houseId, residentId, choreId, 
 
   const filteredPreferences = preferences
     .map(pref => exports.orientChorePreference(choreId, pref))
-    .filter(pref => pref && pref.residentId === residentId);
+    .filter(pref => pref?.residentId === residentId);
 
   const preferenceValues = new Map();
   chores.forEach(chore => preferenceValues.set(chore.id, 0.5));


### PR DESCRIPTION
## Summary
- Convert six `x && x.y` defensive checks to `x?.y` per #293
- No behavior change; semantics preserved at each site

Closes #293

## Test plan
- [x] `pnpm run lint` passes
- [x] `pnpm test` — all 178 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)