### PR TITLE
chore: enforce no-extra-parens via ESLint (#190)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
     'arrow-parens': [ ERROR, 'as-needed', { requireForBlockBody: true } ],
     'comma-dangle': [ ERROR, 'always-multiline' ],
     'eqeqeq': [ ERROR, 'always' ], // eslint-disable-line quote-props
+    'no-extra-parens': [ ERROR, 'all', { conditionalAssign: false, nestedBinaryExpressions: false } ],
     'no-fallthrough': [ ERROR ],
     'no-bitwise': [ ERROR ],
     'no-only-tests/no-only-tests': [ ERROR, { fix: true } ],

--- a/src/bolt/chores/handlers/actions.js
+++ b/src/bolt/chores/handlers/actions.js
@@ -135,11 +135,11 @@ module.exports = (app) => {
 
     assert(choreId || choreValueId, 'Missing choreId or choreValueId');
 
-    const chore = (choreId)
+    const chore = choreId
       ? await Chores.getChore(choreId)
       : await Chores.getSpecialChoreValue(choreValueId);
 
-    const choreValue = (choreId)
+    const choreValue = choreId
       ? await Chores.getCurrentChoreValue(choreId, now)
       : chore.value;
 
@@ -225,7 +225,7 @@ module.exports = (app) => {
     const targetChore = JSON.parse(common.getInputBlock(body, -2).chore.selected_option.value);
     const preference = JSON.parse(common.getInputBlock(body, -1).preference.selected_option.value);
 
-    const actionPreference = (action) ? preference : 1 - preference;
+    const actionPreference = action ? preference : 1 - preference;
 
     const orientedCurrentPreferences = (await Chores.getResidentChorePreferences(houseId, residentId))
       .map(pref => Chores.orientChorePreference(targetChore.id, pref))
@@ -237,7 +237,7 @@ module.exports = (app) => {
 
     const totalObligation = await Chores.getTotalObligation(houseId, now);
 
-    const view = (choreRankings.length)
+    const view = choreRankings.length
       ? views.choresRankView2(actionPreference, targetChore, choreRankings, totalObligation)
       : views.choresRankViewZero(actionPreference);
 
@@ -373,7 +373,7 @@ module.exports = (app) => {
     const points = common.getInputBlock(body, 3).points.value;
     const circumstance = common.getInputBlock(body, 4).circumstance.value;
 
-    if (!(await Admin.isActive(recipientId, now))) {
+    if (!await Admin.isActive(recipientId, now)) {
       const text = `<@${recipientId}> is not active and cannot earn points :confused:`;
       await common.postEphemeral(app, choresConf, residentId, text);
     } else if (points > currentBalance) {
@@ -525,7 +525,7 @@ module.exports = (app) => {
     const claimableUtc = new Date(common.getInputBlock(body, -1).claimable.selected_date);
 
     const claimable = shiftDate(claimableUtc, now.getTimezoneOffset());
-    const valuedAt = (claimable >= now) ? claimable : now;
+    const valuedAt = claimable >= now ? claimable : now;
 
     // Create the special chore proposal
     const [ proposal ] = await Chores.createSpecialChoreProposal(houseId, residentId, name, description, points, valuedAt, now);
@@ -553,7 +553,7 @@ module.exports = (app) => {
     const { houseId, residentId } = common.beginAction('chores-import', body);
     const { choresConf } = await Admin.getHouse(houseId);
 
-    if (!(await common.isAdmin(app, choresConf.oauth, residentId))) {
+    if (!await common.isAdmin(app, choresConf.oauth, residentId)) {
       await common.postEphemeral(app, choresConf, residentId, common.ADMIN_ONLY);
     } else {
       const view = views.choresImportView();

--- a/src/bolt/chores/handlers/commands.js
+++ b/src/bolt/chores/handlers/commands.js
@@ -67,7 +67,7 @@ module.exports = (app) => {
     const { now, houseId } = common.beginCommand('/chores-activate', command);
     const { choresConf } = await Admin.getHouse(houseId);
 
-    if (!(await common.isAdmin(app, choresConf.oauth, command.user_id))) {
+    if (!await common.isAdmin(app, choresConf.oauth, command.user_id)) {
       await respond({ response_type: 'ephemeral', text: common.ADMIN_ONLY });
     } else {
       const residents = await Admin.getResidents(houseId, now);
@@ -128,7 +128,7 @@ module.exports = (app) => {
     const { houseId } = common.beginCommand('/chores-reset', command);
     const { choresConf } = await Admin.getHouse(houseId);
 
-    if (!(await common.isAdmin(app, choresConf.oauth, command.user_id))) {
+    if (!await common.isAdmin(app, choresConf.oauth, command.user_id)) {
       await respond({ response_type: 'ephemeral', text: common.ADMIN_ONLY });
     } else {
       const view = views.choresResetView();

--- a/src/bolt/chores/handlers/events.js
+++ b/src/bolt/chores/handlers/events.js
@@ -18,7 +18,7 @@ module.exports = (app) => {
     const now = new Date();
     const { user } = payload;
 
-    if (!(await houseActive(user.team_id, now))) { return; }
+    if (!await houseActive(user.team_id, now)) { return; }
 
     console.log(`chores user_change - ${user.team_id} x ${user.id}`);
 
@@ -49,13 +49,13 @@ module.exports = (app) => {
     // This bookkeeping is done after returning the view
 
     // Resolve any claims
-    for (const resolvedClaim of (await Chores.resolveChoreClaims(houseId, now))) {
+    for (const resolvedClaim of await Chores.resolveChoreClaims(houseId, now)) {
       console.log(`resolved choreClaim ${resolvedClaim.id}`);
       await common.updateVoteResults(app, choresConf.oauth, resolvedClaim.pollId, now);
     }
 
     // Resolve any proposals
-    for (const resolvedProposal of (await Chores.resolveChoreProposals(houseId, now))) {
+    for (const resolvedProposal of await Chores.resolveChoreProposals(houseId, now)) {
       console.log(`resolved choreProposal ${resolvedProposal.id}`);
       await common.updateVoteResults(app, choresConf.oauth, resolvedProposal.pollId, now);
     }
@@ -92,7 +92,7 @@ module.exports = (app) => {
           let text = ':scroll: *Last month\'s chore points* :scroll: \n';
           text += choreStats.map(cs => `\n${formatStats(cs)}`).join('');
           text += `\n${formatTotalStats(choreStats)}`;
-          text += (!heartsConf) ? `\n\n:heart: Want month-to-month accountability? *Get <${HEARTS_URL}|Hearts>!* :heart:` : '';
+          text += !heartsConf ? `\n\n:heart: Want month-to-month accountability? *Get <${HEARTS_URL}|Hearts>!* :heart:` : '';
           await common.postMessage(app, choresConf, text);
         }
       }

--- a/src/bolt/chores/views/actions.js
+++ b/src/bolt/chores/views/actions.js
@@ -298,7 +298,7 @@ exports.choresRankView = function (choreRankings, totalObligation) {
 };
 
 exports.choresRankView2 = function (preference, targetChore, choreRankings, totalObligation) {
-  const effect = (preference >= 0.5) ? 'prioritize' : 'deprioritize';
+  const effect = preference >= 0.5 ? 'prioritize' : 'deprioritize';
   const magnitude = Math.abs(preference - 0.5) > 0.2 ? 'a lot' : 'a little';
 
   const header = 'Set chore priorities';
@@ -319,7 +319,7 @@ exports.choresRankView2 = function (preference, targetChore, choreRankings, tota
   blocks.push(common.blockDivider());
   blocks.push(common.blockSection(actionText));
   blocks.push(common.blockInput(
-    `by ${(preference >= 0.5) ? 'deprioritizing' : 'prioritizing'}`,
+    `by ${preference >= 0.5 ? 'deprioritizing' : 'prioritizing'}`,
     {
       action_id: 'chores',
       type: 'multi_static_select',
@@ -374,7 +374,7 @@ exports.choresRankView3 = function (targetChore, targetChoreRanking, prefsMetada
 
 exports.choresRankViewZero = function (preference) {
   const header = 'Set chore priorities';
-  const mainText = `No chores available to *${(preference >= 0.5) ? 'deprioritize' : 'prioritize'}*, ` +
+  const mainText = `No chores available to *${preference >= 0.5 ? 'deprioritize' : 'prioritize'}*, ` +
     'most likely because you\'ve put in these preferences already.\n\n' +
     'Try asking someone else to submit the same preferences as you.';
 
@@ -584,7 +584,7 @@ exports.choresProposeAddView = function (force, chore) {
       action_id: 'name',
       type: 'plain_text_input',
       max_length: 50,
-      initial_value: (chore) ? chore.name : undefined,
+      initial_value: chore ? chore.name : undefined,
       placeholder: common.blockPlaintext('Name of the chore'),
     },
   ));
@@ -595,7 +595,7 @@ exports.choresProposeAddView = function (force, chore) {
       type: 'plain_text_input',
       multiline: true,
       max_length: 1000,
-      initial_value: (chore) ? chore.metadata.description : undefined,
+      initial_value: chore ? chore.metadata.description : undefined,
       placeholder: common.blockPlaintext('Describe the chore (bullet points work well)'),
     },
   ));

--- a/src/bolt/chores/views/events.js
+++ b/src/bolt/chores/views/events.js
@@ -28,7 +28,7 @@ exports.choresOnboardView = function () {
 
 exports.choresHomeView = function (choreChannel, choreStats, numActive) {
   const { pointsEarned, pointsOwed } = choreStats;
-  const progressEmoji = (pointsOwed - pointsEarned < Chores.params.penaltyIncrement)
+  const progressEmoji = pointsOwed - pointsEarned < Chores.params.penaltyIncrement
     ? ':white_check_mark:'
     : ':muscle::skin-tone-4:';
 
@@ -40,7 +40,7 @@ exports.choresHomeView = function (choreChannel, choreStats, numActive) {
     'If you feel a chore should be worth more (or less) over time, you can change it\'s *priority*. ' +
     'If you think a chore should be *added*, *changed*, or *removed*, you can propose that too.';
 
-  const pointsText = (pointsOwed > 0)
+  const pointsText = pointsOwed > 0
     ? `You've earned *${pointsEarned} / ${pointsOwed} points* this month ${progressEmoji}`
     : '*You are exempt from chores!* :tada:';
   const activeText = `There are *${numActive} people* around today :sunny:`;

--- a/src/bolt/common.js
+++ b/src/bolt/common.js
@@ -183,7 +183,7 @@ exports.uninstallApp = async function (app, appName, context) {
 };
 
 exports.setChannel = async function (app, oauth, confName, command, respond) {
-  if (!(await exports.isAdmin(app, oauth, command.user_id))) {
+  if (!await exports.isAdmin(app, oauth, command.user_id)) {
     return respond({ response_type: 'ephemeral', text: exports.ADMIN_ONLY });
   } else {
     let joined;
@@ -253,7 +253,7 @@ exports.getWorkspaceMembers = async function (app, oauth) {
 };
 
 exports.pruneWorkspaceMembers = async function (app, oauth, houseId, now) {
-  for (const member of (await exports.getWorkspaceMembers(app, oauth))) {
+  for (const member of await exports.getWorkspaceMembers(app, oauth)) {
     await exports.pruneWorkspaceMember(houseId, member);
   }
 
@@ -301,7 +301,7 @@ exports.parseLowercase = function (text) {
 exports.getInputBlock = function (body, blockIdx) {
   // https://api.slack.com/reference/interaction-payloads/views#view_submission_fields
   // Indexing is based on the entire block, not only the inputs
-  const realIdx = (blockIdx < 0) ? body.view.blocks.length + blockIdx : blockIdx;
+  const realIdx = blockIdx < 0 ? body.view.blocks.length + blockIdx : blockIdx;
   const blockId = body.view.blocks[realIdx].block_id;
   return body.view.state.values[blockId];
 };
@@ -325,7 +325,7 @@ exports.updateVoteCounts = async function (app, oauth, body, action) {
   const channelId = body.channel.id;
   const residentId = body.user.id;
 
-  if (!(await Admin.isActive(residentId, now))) {
+  if (!await Admin.isActive(residentId, now)) {
     const text = ':warning: Inactive residents are not allowed to vote :warning:';
     await exports.postEphemeral(app, { oauth, channel: channelId }, residentId, text);
     return;

--- a/src/bolt/hearts/handlers/actions.js
+++ b/src/bolt/hearts/handlers/actions.js
@@ -29,7 +29,7 @@ module.exports = (app) => {
 
     const unresolvedChallenges = await Hearts.getUnresolvedChallenges(houseId, challengeeId);
 
-    if (!(await Admin.isActive(challengeeId, now))) {
+    if (!await Admin.isActive(challengeeId, now)) {
       const text = `<@${challengeeId}> is not active and cannot be challenged :weary:`;
       await common.postEphemeral(app, heartsConf, residentId, text);
     } else if (unresolvedChallenges.length) {

--- a/src/bolt/hearts/handlers/commands.js
+++ b/src/bolt/hearts/handlers/commands.js
@@ -43,7 +43,7 @@ module.exports = (app) => {
     const { houseId } = common.beginCommand('/hearts-reset', command);
     const { heartsConf } = await Admin.getHouse(houseId);
 
-    if (!(await common.isAdmin(app, heartsConf.oauth, command.user_id))) {
+    if (!await common.isAdmin(app, heartsConf.oauth, command.user_id)) {
       await respond({ response_type: 'ephemeral', text: common.ADMIN_ONLY });
     } else {
       const view = views.heartsResetView();

--- a/src/bolt/hearts/handlers/events.js
+++ b/src/bolt/hearts/handlers/events.js
@@ -23,7 +23,7 @@ module.exports = (app) => {
   app.event('user_change', async ({ payload }) => {
     const [ now, user ] = [ new Date(), payload.user ];
 
-    if (!(await houseActive(user.team_id, now))) { return; }
+    if (!await houseActive(user.team_id, now)) { return; }
 
     console.log(`hearts user_change - ${user.team_id} x ${user.id}`);
 
@@ -47,7 +47,7 @@ module.exports = (app) => {
 
     if (karmaRecipients.length > 0) {
       const [ now, giverId ] = [ new Date(), payload.user ];
-      const houseId = (payload.subtype === 'thread_broadcast') ? payload.root.team : payload.team;
+      const houseId = payload.subtype === 'thread_broadcast' ? payload.root.team : payload.team;
       const { heartsConf } = await Admin.getHouse(houseId);
       console.log(`hearts karma-message - ${houseId} x ${giverId}`);
 
@@ -60,7 +60,7 @@ module.exports = (app) => {
 
     if (karmaRecipients.length > 1 && karmaRecipients.length < 10) {
       const numbers = [ 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine' ];
-      const houseId = (payload.subtype === 'thread_broadcast') ? payload.root.team : payload.team;
+      const houseId = payload.subtype === 'thread_broadcast' ? payload.root.team : payload.team;
       const { heartsConf } = await Admin.getHouse(houseId);
 
       await common.addReaction(app, heartsConf.oauth, payload, numbers[karmaRecipients.length]);
@@ -79,7 +79,7 @@ module.exports = (app) => {
       const isActive = await Admin.isActive(residentId, now);
       const hearts = await Hearts.getHearts(residentId, now);
 
-      view = views.heartsHomeView(heartsConf.channel, isActive, (hearts || 0));
+      view = views.heartsHomeView(heartsConf.channel, isActive, hearts || 0);
     } else {
       view = views.heartsIntroView();
     }
@@ -89,21 +89,21 @@ module.exports = (app) => {
     // This bookkeeping is done after returning the view
 
     // Resolve any challanges
-    for (const resolvedChallenge of (await Hearts.resolveChallenges(houseId, now))) {
+    for (const resolvedChallenge of await Hearts.resolveChallenges(houseId, now)) {
       console.log(`resolved heartChallenge ${resolvedChallenge.id}`);
       await common.updateVoteResults(app, heartsConf.oauth, resolvedChallenge.pollId, now);
     }
 
-    for (const challengeHeart of (await Hearts.getAgnosticHearts(houseId, now))) {
+    for (const challengeHeart of await Hearts.getAgnosticHearts(houseId, now)) {
       const text = `<@${challengeHeart.residentId}> lost a challenge, ` +
         `and *${(-challengeHeart.value).toFixed(0)}* heart(s)...`;
       await common.postMessage(app, heartsConf, text);
     }
 
     // Regenerate lost hearts // fade karma hearts
-    for (const regenHeart of (await Hearts.regenerateHouseHearts(houseId, now))) {
+    for (const regenHeart of await Hearts.regenerateHouseHearts(houseId, now)) {
       if (regenHeart.value !== 0) {
-        const text = (regenHeart.value > 0)
+        const text = regenHeart.value > 0
           ? `You regenerated *${renderValueText(regenHeart.value)}* heart(s)!`
           : `Your karma faded by *${renderValueText(-regenHeart.value)}* heart(s)!`;
         await common.postEphemeral(app, heartsConf, regenHeart.residentId, text);
@@ -114,7 +114,7 @@ module.exports = (app) => {
     const karmaHearts = await Hearts.generateKarmaHearts(houseId, now);
     if (karmaHearts.length) {
       const karmaWinners = karmaHearts.map(heart => `<@${heart.residentId}>`).join(' and ');
-      const text = (karmaHearts.length > 1)
+      const text = karmaHearts.length > 1
         ? `${karmaWinners} get last month's karma hearts :heart_on_fire:`
         : `${karmaWinners} gets last month's karma heart :heart_on_fire:`;
 
@@ -122,7 +122,7 @@ module.exports = (app) => {
     }
 
     // Retire any residents
-    for (const residentId of (await Hearts.retireResidents(houseId, now))) {
+    for (const residentId of await Hearts.retireResidents(houseId, now)) {
       const text = `*<@${residentId}> lost all their hearts* and is deactivated. :sleeping:`;
       await common.postMessage(app, heartsConf, text);
     }

--- a/src/bolt/hearts/views/events.js
+++ b/src/bolt/hearts/views/events.js
@@ -35,7 +35,7 @@ exports.heartsHomeView = function (heartsChannel, isActive, numHearts) {
     'Everyone starts with *5 hearts*. ' +
     'We lose hearts when we fail to uphold our commitments, ' +
     'and we regain hearts *over time* or by earning *karma*.';
-  const activeText = (isActive)
+  const activeText = isActive
     ? `You have *${numHearts}* hearts ${heartEmoji(numHearts)}`
     : '*You are exempt from hearts!* :balloon:';
   const channelText = `Events will be posted in <#${heartsChannel}> :mailbox_with_mail:`;

--- a/src/bolt/hearts/views/utils.js
+++ b/src/bolt/hearts/views/utils.js
@@ -20,7 +20,7 @@ exports.heartEmoji = function (numHearts) {
   }
 
   let text = emoji.repeat(Math.max(1, Math.floor(numHearts)));
-  text += (numHearts % 1 > 0) ? ':heavy_plus_sign:' : '';
+  text += numHearts % 1 > 0 ? ':heavy_plus_sign:' : '';
   return text;
 };
 

--- a/src/bolt/things/handlers/commands.js
+++ b/src/bolt/things/handlers/commands.js
@@ -23,7 +23,7 @@ module.exports = (app) => {
     const { houseId } = common.beginCommand('/things-load', command);
     const { thingsConf } = await Admin.getHouse(houseId);
 
-    if (!(await common.isAdmin(app, thingsConf.oauth, command.user_id))) {
+    if (!await common.isAdmin(app, thingsConf.oauth, command.user_id)) {
       await respond({ response_type: 'ephemeral', text: common.ADMIN_ONLY });
     } else {
       const view = views.thingsLoadView();
@@ -64,7 +64,7 @@ module.exports = (app) => {
     const { now, houseId } = common.beginCommand('/things-fulfill', command);
     const { thingsConf } = await Admin.getHouse(houseId);
 
-    if (!(await common.isAdmin(app, thingsConf.oauth, command.user_id))) {
+    if (!await common.isAdmin(app, thingsConf.oauth, command.user_id)) {
       await respond({ response_type: 'ephemeral', text: common.ADMIN_ONLY });
       return;
     }
@@ -104,7 +104,7 @@ module.exports = (app) => {
     const { houseId } = common.beginCommand('/things-update', command);
     const { thingsConf } = await Admin.getHouse(houseId);
 
-    if (!(await common.isAdmin(app, thingsConf.oauth, command.user_id))) {
+    if (!await common.isAdmin(app, thingsConf.oauth, command.user_id)) {
       await respond({ response_type: 'ephemeral', text: common.ADMIN_ONLY });
     } else {
       const things = await Things.getThings(houseId);

--- a/src/bolt/things/handlers/events.js
+++ b/src/bolt/things/handlers/events.js
@@ -19,7 +19,7 @@ module.exports = (app) => {
   app.event('user_change', async ({ payload }) => {
     const [ now, user ] = [ new Date(), payload.user ];
 
-    if (!(await houseActive(user.team_id, now))) { return; }
+    if (!await houseActive(user.team_id, now)) { return; }
 
     console.log(`things user_change - ${user.team_id} x ${user.id}`);
 
@@ -49,13 +49,13 @@ module.exports = (app) => {
     // This bookkeeping is done after returning the view
 
     // Resolve any buys
-    for (const resolvedBuy of (await Things.resolveThingBuys(houseId, now))) {
+    for (const resolvedBuy of await Things.resolveThingBuys(houseId, now)) {
       console.log(`resolved thingBuy ${resolvedBuy.id}`);
       await common.updateVoteResults(app, thingsConf.oauth, resolvedBuy.pollId, now);
     }
 
     // Resolve any proposals
-    for (const resolvedProposal of (await Things.resolveThingProposals(houseId, now))) {
+    for (const resolvedProposal of await Things.resolveThingProposals(houseId, now)) {
       console.log(`resolved thingProposal ${resolvedProposal.id}`);
       await common.updateVoteResults(app, thingsConf.oauth, resolvedProposal.pollId, now);
     }

--- a/src/bolt/things/views/actions.js
+++ b/src/bolt/things/views/actions.js
@@ -301,7 +301,7 @@ exports.thingsProposeAddView = function (thing, branch = '') {
     {
       action_id: 'type',
       type: 'plain_text_input',
-      initial_value: (thing) ? thing.type : undefined,
+      initial_value: thing ? thing.type : undefined,
       placeholder: common.blockPlaintext('Category of the thing, e.g. Pantry, Beverage'),
     },
   ));
@@ -311,7 +311,7 @@ exports.thingsProposeAddView = function (thing, branch = '') {
       action_id: 'name',
       type: 'plain_text_input',
       max_length: 50,
-      initial_value: (thing) ? thing.name : undefined,
+      initial_value: thing ? thing.name : undefined,
       placeholder: common.blockPlaintext('Name of the thing, e.g. Oat Milk, Salt'),
     },
   ));
@@ -320,7 +320,7 @@ exports.thingsProposeAddView = function (thing, branch = '') {
     {
       action_id: 'unit',
       type: 'plain_text_input',
-      initial_value: (thing) ? thing.metadata.unit : undefined,
+      initial_value: thing ? thing.metadata.unit : undefined,
       placeholder: common.blockPlaintext('Unit sold, e.g. 2 x 24 oz, 2 dozen'),
     },
   ));
@@ -331,7 +331,7 @@ exports.thingsProposeAddView = function (thing, branch = '') {
       type: 'number_input',
       min_value: '1',
       is_decimal_allowed: false,
-      initial_value: (thing) ? thing.value.toString() : undefined,
+      initial_value: thing ? thing.value.toString() : undefined,
       placeholder: common.blockPlaintext('Cost of the thing (including tax & shipping)'),
     },
   ));
@@ -340,7 +340,7 @@ exports.thingsProposeAddView = function (thing, branch = '') {
     {
       action_id: 'url',
       type: 'url_text_input',
-      initial_value: (thing) ? thing.metadata.url : undefined,
+      initial_value: thing ? thing.metadata.url : undefined,
       placeholder: common.blockPlaintext('Link to the thing'),
     },
   ));

--- a/src/bolt/things/views/utils.js
+++ b/src/bolt/things/views/utils.js
@@ -40,7 +40,7 @@ exports.formatBuy = function (buy, url = true) {
 
 function getUrlHost (buy) {
   try {
-    return (new URL(buy.thingMetadata.url)).host;
+    return new URL(buy.thingMetadata.url).host;
   } catch {
     return '';
   }

--- a/src/core/admin.js
+++ b/src/core/admin.js
@@ -98,5 +98,5 @@ exports.getNumResidents = async function (houseId, now) {
 
 exports.isActive = async function (residentId, now) {
   const resident = await exports.getResident(residentId);
-  return (resident?.activeAt && resident.activeAt <= now);
+  return resident?.activeAt && resident.activeAt <= now;
 };

--- a/src/core/chores.js
+++ b/src/core/chores.js
@@ -191,7 +191,7 @@ exports.createSourceExclusionSet = function (orientedPreferences, newValue) {
   const prioritizing = newValue >= 0.5;
   // NOTE: Typescript would be useful here
   return new Set(orientedPreferences
-    .filter(pref => (prioritizing) ? pref.preference >= newValue : pref.preference <= newValue)
+    .filter(pref => prioritizing ? pref.preference >= newValue : pref.preference <= newValue)
     .map(pref => pref.sourceChoreId));
 };
 
@@ -241,7 +241,7 @@ exports.getChoreValue = async function (choreId, startTime, endTime) {
 
 exports.getCurrentChoreValue = async function (choreId, now, excludedClaimId = null) {
   const latestClaim = await exports.getLatestChoreClaim(choreId, now, excludedClaimId);
-  const latestClaimedAt = (latestClaim === undefined) ? new Date(0) : latestClaim.claimedAt;
+  const latestClaimedAt = latestClaim === undefined ? new Date(0) : latestClaim.claimedAt;
   return exports.getChoreValue(choreId, latestClaimedAt, now);
 };
 
@@ -373,7 +373,7 @@ exports.getLastChoreValueUpdateTime = async function (houseId, updateTime) {
     .select('valuedAt')
     .first();
 
-  return (lastChoreValue)
+  return lastChoreValue
     ? lastChoreValue.valuedAt
     : updateTime;
 };
@@ -572,7 +572,7 @@ exports.resolveChoreClaim = async function (claimId, resolvedAt) {
   const valid = await Polls.isPollValid(choreClaim.pollId, resolvedAt);
 
   // If a special chore, no need to recalculate the value
-  const choreValue = (choreClaim.choreId)
+  const choreValue = choreClaim.choreId
     ? await exports.getCurrentChoreValue(choreClaim.choreId, choreClaim.claimedAt, claimId)
     : choreClaim.value;
 
@@ -745,7 +745,7 @@ exports.getChoreStats = async function (houseId, residentId, startTime, endTime)
 
   // Note: special chore obligations are not re-allocated by workingPercentage; so are mildly inflationary
   const pointsOwed = Math.round((residentObligation + specialObligation) * workingPercentage);
-  const completionPct = (pointsOwed) ? pointsEarned / pointsOwed : 1;
+  const completionPct = pointsOwed ? pointsEarned / pointsOwed : 1;
 
   return { pointsEarned, pointsOwed, completionPct, workingPercentage, specialObligation };
 };

--- a/src/core/hearts.js
+++ b/src/core/hearts.js
@@ -79,7 +79,7 @@ exports.generateHearts = async function (houseId, residentId, type, generatedAt,
 };
 
 exports.initialiseResident = async function (houseId, residentId, now) {
-  const hearts = (await exports.getHearts(residentId, now)) || 0;
+  const hearts = await exports.getHearts(residentId, now) || 0;
   if (hearts <= 0) {
     const amount = params.baselineAmount - hearts;
     return exports.generateHearts(houseId, residentId, exports.HEART_REGEN, now, amount);
@@ -131,7 +131,7 @@ exports.getRegenAmount = function (currentHearts) {
   // Want to move `regenAmount` up towards `baselineAmount`
   //   and `fadeAmount` down towards `baselineAmount`
   const baselineGap = params.baselineAmount - currentHearts;
-  return (baselineGap >= 0)
+  return baselineGap >= 0
     ? Math.min(params.regenAmount, baselineGap)
     : Math.max(-params.fadeAmount, baselineGap);
 };
@@ -174,7 +174,7 @@ exports.getUnresolvedChallenges = async function (houseId, challengeeId) {
 exports.getChallengeMinVotes = async function (houseId, challengeeId, value, challengedAt) {
   const residents = await Admin.getResidents(houseId, challengedAt);
   const challengeeHearts = await exports.getHearts(challengeeId, challengedAt);
-  return (challengeeHearts - value <= params.criticalNum)
+  return challengeeHearts - value <= params.criticalNum
     ? Math.ceil(residents.length * params.minPctCritical)
     : Math.ceil(residents.length * params.minPctInitial);
 };
@@ -186,7 +186,7 @@ exports.resolveChallenge = async function (challengeId, resolvedAt) {
   assert(!challenge.heartId, 'Challenge already resolved!');
 
   const valid = await Polls.isPollValid(challenge.pollId, resolvedAt);
-  const loser = (valid) ? challengeeId : challengerId;
+  const loser = valid ? challengeeId : challengerId;
 
   const [ heart ] = await exports.generateHearts(houseId, loser, exports.HEART_CHALLENGE, resolvedAt, -value);
 
@@ -267,7 +267,7 @@ exports.getNumKarmaWinners = async function (houseId, startTime, endTime) {
   const maxWinners = Math.floor(residents.length / params.karmaProportion);
 
   const karma = await exports.getKarma(houseId, startTime, endTime);
-  const uniqueReceivers = (new Set(karma.map(k => k.receiverId))).size;
+  const uniqueReceivers = new Set(karma.map(k => k.receiverId)).size;
 
   return Math.min(maxWinners, uniqueReceivers);
 };
@@ -318,6 +318,6 @@ exports.getKarmaHearts = async function (residentId, now) {
 
 exports.getHeartsVoteScalar = async function (residentId, now) {
   const hearts = await exports.getHearts(residentId, now);
-  const heartsValue = (hearts === null) ? params.baselineAmount : hearts;
+  const heartsValue = hearts === null ? params.baselineAmount : hearts;
   return 1 - ((heartsValue - params.baselineAmount) * params.voteScalar);
 };

--- a/src/core/polls.js
+++ b/src/core/polls.js
@@ -72,7 +72,7 @@ exports.isPollValid = async function (pollId, now) {
   assert(poll.endTime <= now, 'Poll not closed!');
 
   const { yays, nays } = await exports.getPollResultCounts(pollId);
-  return (yays >= poll.minVotes && yays > nays);
+  return yays >= poll.minVotes && yays > nays;
 };
 
 exports.updateMetadata = async function (pollId, metadata) {

--- a/src/core/things.js
+++ b/src/core/things.js
@@ -267,7 +267,7 @@ exports.getThingBuyMinVotes = async function (houseId, boughtBy, thingId, price,
   const minVotesSpecial = Math.ceil(params.minPctSpecial * residents.length);
   const minVotesScaled = Math.ceil(Math.abs(price) / params.minVotesScalar);
 
-  const minVotes = (thingId)
+  const minVotes = thingId
     ? Math.min(maxVotes, minVotesScaled) // Regular buy
     : Math.min(maxVotes, Math.max(minVotesScaled, minVotesSpecial)); // Special buy
 


### PR DESCRIPTION
## Summary
- Adds `no-extra-parens` to `.eslintrc.js` with `conditionalAssign: false` and `nestedBinaryExpressions: false` (so the rule plays nicely with `no-cond-assign` and `no-mixed-operators`)
- Auto-fixes 64 unnecessary parens across 20 source files — all stylistic, no behavior change

Closes #190

## Test plan
- [x] `pnpm run lint` passes
- [x] `pnpm test` — all 178 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)