### PR TITLE
chore(deps): migrate test suite to ESM for Chai 5/6 upgrade

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,7 +33,7 @@ module.exports = [
     },
   },
   {
-    files: [ 'test/**/*.js' ],
+    files: [ 'test/**/*.{js,mjs}' ],
     languageOptions: {
       globals: globals.mocha,
     },

--- a/package.json
+++ b/package.json
@@ -36,9 +36,8 @@
     "voca": "^1.4.1"
   },
   "devDependencies": {
-    "chai": "^4.5.0",
-    "chai-almost": "^1.0.1",
-    "chai-as-promised": "^7.1.2",
+    "chai": "^6.2.2",
+    "chai-as-promised": "^8.0.2",
     "eslint": "^9.39.4",
     "eslint-plugin-no-only-tests": "^3.4.0",
     "husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,14 +46,11 @@ importers:
         version: 1.4.1
     devDependencies:
       chai:
-        specifier: ^4.5.0
-        version: 4.5.0
-      chai-almost:
-        specifier: ^1.0.1
-        version: 1.0.1
+        specifier: ^6.2.2
+        version: 6.2.2
       chai-as-promised:
-        specifier: ^7.1.2
-        version: 7.1.2(chai@4.5.0)
+        specifier: ^8.0.2
+        version: 8.0.2(chai@6.2.2)
       eslint:
         specifier: ^9.39.4
         version: 9.39.4
@@ -654,9 +651,6 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
-  assertion-error@1.1.0:
-    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
-
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
@@ -772,17 +766,14 @@ packages:
   caniuse-lite@1.0.30001741:
     resolution: {integrity: sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==}
 
-  chai-almost@1.0.1:
-    resolution: {integrity: sha512-UrNSx5f2B1/ESrOz0a4iLpDnQvDnK/3O0ZE/KGYQ+NcndKy0VQkMkv8yoGIHNSbjzKBid3EAMdDMA5wb9CxvSA==}
-
-  chai-as-promised@7.1.2:
-    resolution: {integrity: sha512-aBDHZxRzYnUYuIAIPBH2s511DjlKPzXNlXSGFC8CwmroWQLfrW0LtE1nK3MAwwNhJPa9raEjNCmRoFpG0Hurdw==}
+  chai-as-promised@8.0.2:
+    resolution: {integrity: sha512-1GadL+sEJVLzDjcawPM4kjfnL+p/9vrxiEUonowKOAzvVg0PixJUdtuDzdkDeQhK3zfOE76GqGkZIQ7/Adcrqw==}
     peerDependencies:
-      chai: '>= 2.1.2 < 6'
+      chai: '>= 2.1.2 < 7'
 
-  chai@4.5.0:
-    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
-    engines: {node: '>=4'}
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -792,8 +783,9 @@ packages:
     resolution: {integrity: sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw==}
     engines: {node: '>=16'}
 
-  check-error@1.0.3:
-    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -923,14 +915,6 @@ packages:
   decamelize@4.0.0:
     resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
     engines: {node: '>=10'}
-
-  deep-eql@2.0.2:
-    resolution: {integrity: sha512-uts3fF4HnV1bcNx8K5c9NMjXXKtLOf1obUMq04uEuMaF8i1m0SfugbpDMd59cYfodQcMqeUISvL4Pmx5NZ7lcw==}
-    engines: {node: '>=0.12'}
-
-  deep-eql@4.1.4:
-    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
-    engines: {node: '>=6'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -1308,9 +1292,6 @@ packages:
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
-
-  get-func-name@2.0.2:
-    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -1841,9 +1822,6 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  loupe@2.3.7:
-    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
-
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -2132,9 +2110,6 @@ packages:
 
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
-
-  pathval@1.1.1:
-    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
   peowly@1.3.3:
     resolution: {integrity: sha512-5UmUtvuCv3KzBX2NuQw2uF28o0t8Eq4KkPRZfUCzJs+DiNVKw7OaYn29vNDgrt/Pggs23CPlSTqgzlhHJfpT0A==}
@@ -2608,13 +2583,6 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
-
-  type-detect@3.0.0:
-    resolution: {integrity: sha512-pwZo7l1T0a8wmTMDc4FtXuHseRaqa9nyaUArp4xHaBMUlRzr72PvgF6ouXIIj5rjbVWqo8pZu6vw74jDKg4Dvw==}
-
-  type-detect@4.1.0:
-    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
-    engines: {node: '>=4'}
 
   type-fest@0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
@@ -3599,8 +3567,6 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
-  assertion-error@1.1.0: {}
-
   astring@1.9.0: {}
 
   async-function@1.0.0: {}
@@ -3737,25 +3703,12 @@ snapshots:
 
   caniuse-lite@1.0.30001741: {}
 
-  chai-almost@1.0.1:
+  chai-as-promised@8.0.2(chai@6.2.2):
     dependencies:
-      deep-eql: 2.0.2
-      type-detect: 4.1.0
+      chai: 6.2.2
+      check-error: 2.1.3
 
-  chai-as-promised@7.1.2(chai@4.5.0):
-    dependencies:
-      chai: 4.5.0
-      check-error: 1.0.3
-
-  chai@4.5.0:
-    dependencies:
-      assertion-error: 1.1.0
-      check-error: 1.0.3
-      deep-eql: 4.1.4
-      get-func-name: 2.0.2
-      loupe: 2.3.7
-      pathval: 1.1.1
-      type-detect: 4.1.0
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -3764,9 +3717,7 @@ snapshots:
 
   check-disk-space@3.4.0: {}
 
-  check-error@1.0.3:
-    dependencies:
-      get-func-name: 2.0.2
+  check-error@2.1.3: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -3873,14 +3824,6 @@ snapshots:
   decamelize@1.2.0: {}
 
   decamelize@4.0.0: {}
-
-  deep-eql@2.0.2:
-    dependencies:
-      type-detect: 3.0.0
-
-  deep-eql@4.1.4:
-    dependencies:
-      type-detect: 4.1.0
 
   deep-is@0.1.4: {}
 
@@ -4424,8 +4367,6 @@ snapshots:
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
-
-  get-func-name@2.0.2: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -4973,10 +4914,6 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  loupe@2.3.7:
-    dependencies:
-      get-func-name: 2.0.2
-
   lru-cache@10.4.3: {}
 
   lru-cache@11.3.5: {}
@@ -5336,8 +5273,6 @@ snapshots:
       minipass: 7.1.3
 
   path-to-regexp@8.3.0: {}
-
-  pathval@1.1.1: {}
 
   peowly@1.3.3: {}
 
@@ -5879,10 +5814,6 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-
-  type-detect@3.0.0: {}
-
-  type-detect@4.1.0: {}
 
   type-fest@0.8.1: {}
 

--- a/test/admin.test.mjs
+++ b/test/admin.test.mjs
@@ -1,12 +1,8 @@
-const { expect } = require('chai');
-const chai = require('chai');
-const chaiAsPromised = require('chai-as-promised');
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 
-chai.use(chaiAsPromised);
-
-const { Admin } = require('../src/core/index');
-
-const {
+import { Admin } from '../src/core/index.js';
+import {
   HOUR,
   DAY,
   getMonthStart,
@@ -15,9 +11,10 @@ const {
   getPrevMonthEnd,
   getDateStart,
   truncateHour,
-} = require('../src/time');
+} from '../src/time.js';
+import * as testHelpers from './helpers.mjs';
 
-const testHelpers = require('./helpers');
+use(chaiAsPromised);
 
 describe('Admin', async () => {
   const HOUSE1 = testHelpers.generateSlackId();

--- a/test/chores.test.mjs
+++ b/test/chores.test.mjs
@@ -1,15 +1,9 @@
-const { expect } = require('chai');
-const chai = require('chai');
-const chaiAlmost = require('chai-almost');
-const chaiAsPromised = require('chai-as-promised');
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 
-chai.use(chaiAlmost());
-chai.use(chaiAsPromised);
-
-const { db } = require('../src/core/db');
-const { Chores, Hearts, Polls, Admin } = require('../src/core/index');
-
-const {
+import { db } from '../src/core/db.js';
+import { Chores, Hearts, Polls, Admin } from '../src/core/index.js';
+import {
   DAY,
   HOUR,
   MINUTE,
@@ -17,9 +11,10 @@ const {
   getMonthEnd,
   getNextMonthStart,
   getPrevMonthEnd,
-} = require('../src/time');
+} from '../src/time.js';
+import * as testHelpers from './helpers.mjs';
 
-const testHelpers = require('./helpers');
+use(chaiAsPromised);
 
 describe('Chores', async () => {
   const HOUSE = testHelpers.generateSlackId();
@@ -173,14 +168,14 @@ describe('Chores', async () => {
       pref = Chores.normalizeChorePreference({ targetChoreId: dishes.id, sourceChoreId: sweeping.id, preference: 0.7 });
       expect(pref.alphaChoreId).to.equal(dishes.id);
       expect(pref.betaChoreId).to.equal(sweeping.id);
-      expect(pref.preference).to.almost.equal(0.7);
+      expect(pref.preference).to.be.closeTo(0.7, 1e-6);
 
       expect(dishes.id).to.be.lt(sweeping.id);
 
       pref = Chores.normalizeChorePreference({ targetChoreId: sweeping.id, sourceChoreId: dishes.id, preference: 0.7 });
       expect(pref.alphaChoreId).to.equal(dishes.id);
       expect(pref.betaChoreId).to.equal(sweeping.id);
-      expect(pref.preference).to.almost.equal(0.3);
+      expect(pref.preference).to.be.closeTo(0.3, 1e-6);
 
       expect(() => Chores.normalizeChorePreference({ alphaChoreId: sweeping.id, betaChoreId: dishes.id, preference: 0.7 }))
         .to.throw('Invalid chore preference!');
@@ -192,12 +187,12 @@ describe('Chores', async () => {
       pref = Chores.orientChorePreference(dishes.id, { alphaChoreId: dishes.id, betaChoreId: sweeping.id, preference: 0.7 });
       expect(pref.targetChoreId).to.equal(dishes.id);
       expect(pref.sourceChoreId).to.equal(sweeping.id);
-      expect(pref.preference).to.almost.equal(0.7);
+      expect(pref.preference).to.be.closeTo(0.7, 1e-6);
 
       pref = Chores.orientChorePreference(sweeping.id, { alphaChoreId: dishes.id, betaChoreId: sweeping.id, preference: 0.7 });
       expect(pref.targetChoreId).to.equal(sweeping.id);
       expect(pref.sourceChoreId).to.equal(dishes.id);
-      expect(pref.preference).to.almost.equal(0.3);
+      expect(pref.preference).to.be.closeTo(0.3, 1e-6);
 
       pref = Chores.orientChorePreference(restock.id, { alphaChoreId: dishes.id, betaChoreId: sweeping.id, preference: 0.7 });
       expect(pref).to.be.undefined;
@@ -318,9 +313,9 @@ describe('Chores', async () => {
     it('can return uniform rankings implicitly', async () => {
       const choreRankings = await Chores.getCurrentChoreRankings(HOUSE, now);
 
-      expect(choreRankings.find(x => x.id === dishes.id).ranking).to.almost.equal(0.3333333333333333);
-      expect(choreRankings.find(x => x.id === sweeping.id).ranking).to.almost.equal(0.3333333333333333);
-      expect(choreRankings.find(x => x.id === restock.id).ranking).to.almost.equal(0.3333333333333333);
+      expect(choreRankings.find(x => x.id === dishes.id).ranking).to.be.closeTo(0.3333333333333333, 1e-6);
+      expect(choreRankings.find(x => x.id === sweeping.id).ranking).to.be.closeTo(0.3333333333333333, 1e-6);
+      expect(choreRankings.find(x => x.id === restock.id).ranking).to.be.closeTo(0.3333333333333333, 1e-6);
     });
 
     it('can use preferences to determine chore rankings', async () => {
@@ -330,9 +325,9 @@ describe('Chores', async () => {
 
       const choreRankings = await Chores.getCurrentChoreRankings(HOUSE, now);
 
-      expect(choreRankings.find(x => x.id === dishes.id).ranking).to.almost.equal(0.6504044299518104);
-      expect(choreRankings.find(x => x.id === sweeping.id).ranking).to.almost.equal(0.25639052368514753);
-      expect(choreRankings.find(x => x.id === restock.id).ranking).to.almost.equal(0.093205046363043);
+      expect(choreRankings.find(x => x.id === dishes.id).ranking).to.be.closeTo(0.6504044299518104, 1e-6);
+      expect(choreRankings.find(x => x.id === sweeping.id).ranking).to.be.closeTo(0.25639052368514753, 1e-6);
+      expect(choreRankings.find(x => x.id === restock.id).ranking).to.be.closeTo(0.093205046363043, 1e-6);
     });
 
     it('can use preferences to determine mild chore rankings', async () => {
@@ -342,9 +337,9 @@ describe('Chores', async () => {
 
       const choreRankings = await Chores.getCurrentChoreRankings(HOUSE, now);
 
-      expect(choreRankings.find(x => x.id === dishes.id).ranking).to.almost.equal(0.5109403527338869);
-      expect(choreRankings.find(x => x.id === sweeping.id).ranking).to.almost.equal(0.32920913470298835);
-      expect(choreRankings.find(x => x.id === restock.id).ranking).to.almost.equal(0.15985051256312477);
+      expect(choreRankings.find(x => x.id === dishes.id).ranking).to.be.closeTo(0.5109403527338869, 1e-6);
+      expect(choreRankings.find(x => x.id === sweeping.id).ranking).to.be.closeTo(0.32920913470298835, 1e-6);
+      expect(choreRankings.find(x => x.id === restock.id).ranking).to.be.closeTo(0.15985051256312477, 1e-6);
     });
 
     it('can use preferences to determine complex chore rankings', async () => {
@@ -354,9 +349,9 @@ describe('Chores', async () => {
 
       const choreRankings = await Chores.getCurrentChoreRankings(HOUSE, now);
 
-      expect(choreRankings.find(x => x.id === dishes.id).ranking).to.almost.equal(0.45208724954750107);
-      expect(choreRankings.find(x => x.id === sweeping.id).ranking).to.almost.equal(0.09582550090499836);
-      expect(choreRankings.find(x => x.id === restock.id).ranking).to.almost.equal(0.45208724954750096);
+      expect(choreRankings.find(x => x.id === dishes.id).ranking).to.be.closeTo(0.45208724954750107, 1e-6);
+      expect(choreRankings.find(x => x.id === sweeping.id).ranking).to.be.closeTo(0.09582550090499836, 1e-6);
+      expect(choreRankings.find(x => x.id === restock.id).ranking).to.be.closeTo(0.45208724954750096, 1e-6);
     });
 
     it('can handle circular chore rankings', async () => {
@@ -367,9 +362,9 @@ describe('Chores', async () => {
 
       const choreRankings = await Chores.getCurrentChoreRankings(HOUSE, now);
 
-      expect(choreRankings[0].ranking).to.almost.equal(0.3333333333333333);
-      expect(choreRankings[1].ranking).to.almost.equal(0.3333333333333333);
-      expect(choreRankings[2].ranking).to.almost.equal(0.3333333333333333);
+      expect(choreRankings[0].ranking).to.be.closeTo(0.3333333333333333, 1e-6);
+      expect(choreRankings[1].ranking).to.be.closeTo(0.3333333333333333, 1e-6);
+      expect(choreRankings[2].ranking).to.be.closeTo(0.3333333333333333, 1e-6);
     });
 
     it('can get proposed chore rankings', async () => {
@@ -382,26 +377,26 @@ describe('Chores', async () => {
       const newPrefs = [];
       choreRankings = await Chores.getProposedChoreRankings(HOUSE, newPrefs, now);
 
-      expect(choreRankings.find(x => x.id === dishes.id).ranking).to.almost.equal(0.6504044299518104);
-      expect(choreRankings.find(x => x.id === sweeping.id).ranking).to.almost.equal(0.25639052368514753);
-      expect(choreRankings.find(x => x.id === restock.id).ranking).to.almost.equal(0.093205046363043);
+      expect(choreRankings.find(x => x.id === dishes.id).ranking).to.be.closeTo(0.6504044299518104, 1e-6);
+      expect(choreRankings.find(x => x.id === sweeping.id).ranking).to.be.closeTo(0.25639052368514753, 1e-6);
+      expect(choreRankings.find(x => x.id === restock.id).ranking).to.be.closeTo(0.093205046363043, 1e-6);
 
       // Shift priority from dishes to sweeping
       newPrefs.push({ residentId: RESIDENT1, alphaChoreId: dishes.id, betaChoreId: sweeping.id, preference: 0.7 });
       choreRankings = await Chores.getProposedChoreRankings(HOUSE, newPrefs, now);
 
       // Note how sweeping gains a higher priority despite being less preferred than dishes
-      expect(choreRankings.find(x => x.id === dishes.id).ranking).to.almost.equal(0.4395874692001581);
-      expect(choreRankings.find(x => x.id === sweeping.id).ranking).to.almost.equal(0.43882103155500896);
-      expect(choreRankings.find(x => x.id === restock.id).ranking).to.almost.equal(0.12159149924483303);
+      expect(choreRankings.find(x => x.id === dishes.id).ranking).to.be.closeTo(0.4395874692001581, 1e-6);
+      expect(choreRankings.find(x => x.id === sweeping.id).ranking).to.be.closeTo(0.43882103155500896, 1e-6);
+      expect(choreRankings.find(x => x.id === restock.id).ranking).to.be.closeTo(0.12159149924483303, 1e-6);
 
       // Shift priority from sweeping to restock
       newPrefs.push({ residentId: RESIDENT2, alphaChoreId: sweeping.id, betaChoreId: restock.id, preference: 0.7 });
       choreRankings = await Chores.getProposedChoreRankings(HOUSE, newPrefs, now);
 
-      expect(choreRankings.find(x => x.id === dishes.id).ranking).to.almost.equal(0.5109403527338869);
-      expect(choreRankings.find(x => x.id === sweeping.id).ranking).to.almost.equal(0.32920913470298835);
-      expect(choreRankings.find(x => x.id === restock.id).ranking).to.almost.equal(0.15985051256312477);
+      expect(choreRankings.find(x => x.id === dishes.id).ranking).to.be.closeTo(0.5109403527338869, 1e-6);
+      expect(choreRankings.find(x => x.id === sweeping.id).ranking).to.be.closeTo(0.32920913470298835, 1e-6);
+      expect(choreRankings.find(x => x.id === restock.id).ranking).to.be.closeTo(0.15985051256312477, 1e-6);
     });
   });
 
@@ -459,17 +454,17 @@ describe('Chores', async () => {
 
       // If no prior update, return the current time
       updateTime = await Chores.getLastChoreValueUpdateTime(HOUSE, t1);
-      expect(updateTime.getTime()).to.almost.equal(t1.getTime());
+      expect(updateTime.getTime()).to.be.closeTo(t1.getTime(), 1e-6);
 
       await db('ChoreValue').insert([
         { houseId: HOUSE, choreId: dishes.id, valuedAt: t1, value: 0 },
       ]);
 
       updateTime = await Chores.getLastChoreValueUpdateTime(HOUSE, t1);
-      expect(updateTime.getTime()).to.almost.equal(t1.getTime());
+      expect(updateTime.getTime()).to.be.closeTo(t1.getTime(), 1e-6);
 
       updateTime = await Chores.getLastChoreValueUpdateTime(HOUSE, t2);
-      expect(updateTime.getTime()).to.almost.equal(t1.getTime());
+      expect(updateTime.getTime()).to.be.closeTo(t1.getTime(), 1e-6);
 
       // Adding a special chore value does not affect the update time
       await db('ChoreValue').insert([
@@ -477,7 +472,7 @@ describe('Chores', async () => {
       ]);
 
       updateTime = await Chores.getLastChoreValueUpdateTime(HOUSE, t2);
-      expect(updateTime.getTime()).to.almost.equal(t1.getTime());
+      expect(updateTime.getTime()).to.be.closeTo(t1.getTime(), 1e-6);
     });
 
     it('can get the number of available points', async () => {
@@ -490,15 +485,15 @@ describe('Chores', async () => {
 
       // Half month
       availablePoints = await Chores.getTotalAvailablePoints(HOUSE, t0, t1);
-      expect(availablePoints).to.almost.equal(3 * PPR / 2);
+      expect(availablePoints).to.be.closeTo(3 * PPR / 2, 1e-6);
 
       // Whole month
       availablePoints = await Chores.getTotalAvailablePoints(HOUSE, t0, t2);
-      expect(availablePoints).to.almost.equal(3 * PPR);
+      expect(availablePoints).to.be.closeTo(3 * PPR, 1e-6);
 
       // Three months
       availablePoints = await Chores.getTotalAvailablePoints(HOUSE, t0, t3);
-      expect(availablePoints).to.almost.equal(3 * PPR * 3);
+      expect(availablePoints).to.be.closeTo(3 * PPR * 3, 1e-6);
     });
 
     it('can update chore values on an 3-hourly basis', async () => {
@@ -522,14 +517,14 @@ describe('Chores', async () => {
       // Skip t2, do the update at 60 minutes past the hour
       choreValues = await Chores.updateChoreValues(HOUSE, t3);
       expect(choreValues.length).to.equal(3);
-      expect(choreValues[0].metadata.ranking).to.almost.equal(1 / 3);
-      expect(choreValues[0].metadata.availablePoints).to.almost.equal(3 * PPR * 3 / 720);
+      expect(choreValues[0].metadata.ranking).to.be.closeTo(1 / 3, 1e-6);
+      expect(choreValues[0].metadata.availablePoints).to.be.closeTo(3 * PPR * 3 / 720, 1e-6);
 
       // This update succeeds since the previous update was truncated
       choreValues = await Chores.updateChoreValues(HOUSE, t4);
       expect(choreValues.length).to.equal(3);
-      expect(choreValues[0].metadata.ranking).to.almost.equal(1 / 3);
-      expect(choreValues[0].metadata.availablePoints).to.almost.equal(3 * PPR * 3 / 720);
+      expect(choreValues[0].metadata.ranking).to.be.closeTo(1 / 3, 1e-6);
+      expect(choreValues[0].metadata.availablePoints).to.be.closeTo(3 * PPR * 3 / 720, 1e-6);
     });
 
     it('can update chore values sensibly after a bootstrap', async () => {
@@ -544,8 +539,8 @@ describe('Chores', async () => {
       // Only adds 2 hours of value
       const choreValues = await Chores.getUpdatedChoreValues(HOUSE, t2);
       expect(choreValues.length).to.equal(3);
-      expect(choreValues[0].value).to.almost.equal(PPR * 2 / 720 + 10);
-      expect(choreValues[1].value).to.almost.equal(PPR * 2 / 720);
+      expect(choreValues[0].value).to.be.closeTo(PPR * 2 / 720 + 10, 1e-6);
+      expect(choreValues[1].value).to.be.closeTo(PPR * 2 / 720, 1e-6);
     });
 
     it('can do an end-to-end update of chore values', async () => {
@@ -571,20 +566,20 @@ describe('Chores', async () => {
       expect(lastUpdateTime.getTime()).to.equal(t0.getTime());
 
       availablePoints = await Chores.getTotalAvailablePoints(HOUSE, t0, t3);
-      expect(availablePoints).to.almost.equal(3 * PPR);
+      expect(availablePoints).to.be.closeTo(3 * PPR, 1e-6);
 
       choreValues = await Chores.updateChoreValues(HOUSE, t1);
-      expect(choreValues.reduce((sum, cv) => sum + cv.value, 0)).to.be.almost(3 * PPR / 3, 1e-4);
+      expect(choreValues.reduce((sum, cv) => sum + cv.value, 0)).to.be.closeTo(3 * PPR / 3, 1e-4);
 
       // t2, 10 days later
       lastUpdateTime = await Chores.getLastChoreValueUpdateTime(HOUSE, t2);
       expect(lastUpdateTime.getTime()).to.equal(t1.getTime());
 
       availablePoints = await Chores.getTotalAvailablePoints(HOUSE, t1, t3);
-      expect(availablePoints).to.almost.equal(3 * PPR * 2 / 3);
+      expect(availablePoints).to.be.closeTo(3 * PPR * 2 / 3, 1e-6);
 
       choreValues = await Chores.updateChoreValues(HOUSE, t2);
-      expect(choreValues.reduce((sum, cv) => sum + cv.value, 0)).to.be.almost(3 * PPR / 3, 1e-4);
+      expect(choreValues.reduce((sum, cv) => sum + cv.value, 0)).to.be.closeTo(3 * PPR / 3, 1e-4);
     });
 
     it('can get the current, updated chore values', async () => {
@@ -595,7 +590,7 @@ describe('Chores', async () => {
 
       // Calculate the initial 72 hour update (3 days)
       const choreValues = await Chores.getUpdatedChoreValues(HOUSE, t1);
-      expect(choreValues.reduce((sum, cv) => sum + cv.value, 0)).to.almost.equal(3 * PPR * 3 / 30);
+      expect(choreValues.reduce((sum, cv) => sum + cv.value, 0)).to.be.closeTo(3 * PPR * 3 / 30, 1e-6);
     });
 
     it('can incorporate chore breaks when calculating chore values', async () => {
@@ -612,17 +607,17 @@ describe('Chores', async () => {
 
       // 1/3
       choreValues = await Chores.getUpdatedChoreValues(HOUSE, t1);
-      expect(reduce(choreValues)).to.be.almost(3 * PPR * (1 / 3), 1e-5);
+      expect(reduce(choreValues)).to.be.closeTo(3 * PPR * (1 / 3), 1e-5);
 
       await Chores.addChoreBreak(HOUSE, RESIDENT1, t1, new Date(t2.getTime() + DAY), '');
 
       // 1/3 + 2/9 = 5/9
       choreValues = await Chores.getUpdatedChoreValues(HOUSE, t2);
-      expect(reduce(choreValues)).to.be.almost(3 * PPR * (5 / 9), 1e-4);
+      expect(reduce(choreValues)).to.be.closeTo(3 * PPR * (5 / 9), 1e-4);
 
       // 1/3 + 2/9 + 1/3 = 8/9
       choreValues = await Chores.getUpdatedChoreValues(HOUSE, t3);
-      expect(reduce(choreValues)).to.be.almost(3 * PPR * (8 / 9), 1e-4);
+      expect(reduce(choreValues)).to.be.closeTo(3 * PPR * (8 / 9), 1e-4);
     });
 
     it('can return sensible chore values when initialised part-way through the month', async () => {
@@ -642,7 +637,7 @@ describe('Chores', async () => {
 
       // Calculate the next 10 days
       const choreValues = await Chores.getUpdatedChoreValues(HOUSE, t2);
-      expect(choreValues.reduce((sum, cv) => sum + cv.value, 0)).to.be.almost(3 * PPR * 10 / 30, 1e-5);
+      expect(choreValues.reduce((sum, cv) => sum + cv.value, 0)).to.be.closeTo(3 * PPR * 10 / 30, 1e-5);
     });
 
     it('can return sensible chore values when updating across the month boundary', async () => {
@@ -659,15 +654,15 @@ describe('Chores', async () => {
 
       // 20 days, within a single month
       choreValues = await Chores.getUpdatedChoreValues(HOUSE, t1);
-      expect(choreValues.reduce((sum, cv) => sum + cv.value, 0)).to.be.almost(3 * PPR * 2 / 3, 1e-5);
+      expect(choreValues.reduce((sum, cv) => sum + cv.value, 0)).to.be.closeTo(3 * PPR * 2 / 3, 1e-5);
 
       // 41 days, crossing one month boundary and completing the next month
       choreValues = await Chores.getUpdatedChoreValues(HOUSE, t2);
-      expect(choreValues.reduce((sum, cv) => sum + cv.value, 0)).to.be.almost(3 * PPR * 2, 1e-4);
+      expect(choreValues.reduce((sum, cv) => sum + cv.value, 0)).to.be.closeTo(3 * PPR * 2, 1e-4);
 
       // 61 days, crossing two month boundaries and completing the next two months
       choreValues = await Chores.getUpdatedChoreValues(HOUSE, t3);
-      expect(choreValues.reduce((sum, cv) => sum + cv.value, 0)).to.be.almost(3 * PPR * 4);
+      expect(choreValues.reduce((sum, cv) => sum + cv.value, 0)).to.be.closeTo(3 * PPR * 4, 1e-6);
     });
 
     it('sets ping to true when the value crosses the ping interval', async () => {
@@ -1274,14 +1269,14 @@ describe('Chores', async () => {
 
       // Check values
       choreValues = await Chores.getUpdatedChoreValues(HOUSE, feb15);
-      expect(choreValues.find(cv => cv.choreId === dishes.id).value).to.be.almost(ppc * 0.25, 1e-5);
-      expect(choreValues.find(cv => cv.choreId === sweeping.id).value).to.be.almost(ppc * 0, 1e-5);
-      expect(choreValues.find(cv => cv.choreId === restock.id).value).to.be.almost(ppc * 0.5, 1e-5);
+      expect(choreValues.find(cv => cv.choreId === dishes.id).value).to.be.closeTo(ppc * 0.25, 1e-5);
+      expect(choreValues.find(cv => cv.choreId === sweeping.id).value).to.be.closeTo(ppc * 0, 1e-5);
+      expect(choreValues.find(cv => cv.choreId === restock.id).value).to.be.closeTo(ppc * 0.5, 1e-5);
 
       choreStats = await Chores.getHouseChoreStats(HOUSE, feb1, feb15);
-      expect(choreStats.find(cs => cs.residentId === RESIDENT1).pointsEarned).to.be.almost(ppc * 0.25, 1e-5);
-      expect(choreStats.find(cs => cs.residentId === RESIDENT2).pointsEarned).to.be.almost(ppc * 0.5, 1e-5);
-      expect(choreStats.find(cs => cs.residentId === RESIDENT3).pointsEarned).to.be.almost(ppc * 0, 1e-5);
+      expect(choreStats.find(cs => cs.residentId === RESIDENT1).pointsEarned).to.be.closeTo(ppc * 0.25, 1e-5);
+      expect(choreStats.find(cs => cs.residentId === RESIDENT2).pointsEarned).to.be.closeTo(ppc * 0.5, 1e-5);
+      expect(choreStats.find(cs => cs.residentId === RESIDENT3).pointsEarned).to.be.closeTo(ppc * 0, 1e-5);
       expect(choreStats.find(cs => cs.residentId === RESIDENT1).pointsOwed).to.equal(ppr);
       expect(choreStats.find(cs => cs.residentId === RESIDENT2).pointsOwed).to.equal(ppr);
       expect(choreStats.find(cs => cs.residentId === RESIDENT3).pointsOwed).to.equal(ppr);
@@ -1307,12 +1302,12 @@ describe('Chores', async () => {
       await Chores.claimChore(HOUSE, restock.id, RESIDENT3, feb22, 0);
 
       choreValues = await Chores.getUpdatedChoreValues(HOUSE, feb22);
-      expect(choreValues.find(cv => cv.choreId === dishes.id).value).to.be.almost(ppc * 0.25, 1e-5);
-      expect(choreValues.find(cv => cv.choreId === sweeping.id).value).to.be.almost(ppc * 0.25, 1e-5);
-      expect(choreValues.find(cv => cv.choreId === restock.id).value).to.be.almost(ppc * 0, 1e-5);
+      expect(choreValues.find(cv => cv.choreId === dishes.id).value).to.be.closeTo(ppc * 0.25, 1e-5);
+      expect(choreValues.find(cv => cv.choreId === sweeping.id).value).to.be.closeTo(ppc * 0.25, 1e-5);
+      expect(choreValues.find(cv => cv.choreId === restock.id).value).to.be.closeTo(ppc * 0, 1e-5);
 
       choreStats = await Chores.getHouseChoreStats(HOUSE, feb1, feb22);
-      expect(choreStats.find(cs => cs.residentId === RESIDENT3).pointsEarned).to.be.almost(ppc * 0.25, 1e-5);
+      expect(choreStats.find(cs => cs.residentId === RESIDENT3).pointsEarned).to.be.closeTo(ppc * 0.25, 1e-5);
     });
 
     it('can check if a house is active using claims', async () => {

--- a/test/hearts.test.mjs
+++ b/test/hearts.test.mjs
@@ -1,13 +1,11 @@
-const { expect } = require('chai');
-const chai = require('chai');
-const chaiAsPromised = require('chai-as-promised');
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 
-chai.use(chaiAsPromised);
+import { Hearts, Polls, Admin } from '../src/core/index.js';
+import { HOUR, DAY, getNextMonthStart } from '../src/time.js';
+import * as testHelpers from './helpers.mjs';
 
-const { Hearts, Polls, Admin } = require('../src/core/index');
-const { HOUR, DAY, getNextMonthStart } = require('../src/time');
-
-const testHelpers = require('./helpers');
+use(chaiAsPromised);
 
 describe('Hearts', async () => {
   const { HEART_UNKNOWN, HEART_CHALLENGE, HEART_KARMA } = Hearts;
@@ -211,11 +209,11 @@ describe('Hearts', async () => {
 
   describe('regenerating hearts', async () => {
     it('can calculate the regen amount', async () => {
-      expect(Hearts.getRegenAmount(1.0)).to.almost.equal(0.5);
-      expect(Hearts.getRegenAmount(4.9)).to.almost.equal(0.1);
-      expect(Hearts.getRegenAmount(5.0)).to.almost.equal(0.0);
-      expect(Hearts.getRegenAmount(5.1)).to.almost.equal(-0.1);
-      expect(Hearts.getRegenAmount(7.0)).to.almost.equal(-0.5);
+      expect(Hearts.getRegenAmount(1.0)).to.be.closeTo(0.5, 1e-6);
+      expect(Hearts.getRegenAmount(4.9)).to.be.closeTo(0.1, 1e-6);
+      expect(Hearts.getRegenAmount(5.0)).to.be.closeTo(0.0, 1e-6);
+      expect(Hearts.getRegenAmount(5.1)).to.be.closeTo(-0.1, 1e-6);
+      expect(Hearts.getRegenAmount(7.0)).to.be.closeTo(-0.5, 1e-6);
     });
 
     it('can regenerate hearts', async () => {

--- a/test/helpers.mjs
+++ b/test/helpers.mjs
@@ -1,23 +1,23 @@
-const randomstring = require('randomstring');
-const { Admin } = require('../src/core/index');
-const { db } = require('../src/core/db');
+import randomstring from 'randomstring';
+import { Admin } from '../src/core/index.js';
+import { db } from '../src/core/db.js';
 
-exports.generateSlackId = function () {
+export function generateSlackId () {
   return randomstring.generate({
     charset: 'alphanumeric',
     capitalization: 'uppercase',
     length: 11,
   });
-};
+}
 
-exports.createActiveUsers = async function (houseId, num, now) {
+export async function createActiveUsers (houseId, num, now) {
   for (let i = 0; i < num; i++) {
-    const residentId = exports.generateSlackId();
+    const residentId = generateSlackId();
     await Admin.activateResident(houseId, residentId, now);
   }
-};
+}
 
-exports.resetDb = async function () {
+export async function resetDb () {
   await db('ThingProposal').del();
   await db('ThingBuy').del();
   await db('Thing').del();
@@ -38,4 +38,4 @@ exports.resetDb = async function () {
 
   await db('Resident').del();
   await db('House').del();
-};
+}

--- a/test/polls.test.mjs
+++ b/test/polls.test.mjs
@@ -1,13 +1,12 @@
-const { expect } = require('chai');
-const chai = require('chai');
-const chaiAsPromised = require('chai-as-promised');
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 
-chai.use(chaiAsPromised);
+import { Polls, Admin } from '../src/core/index.js';
+import { HOUR, DAY } from '../src/time.js';
+import { db } from '../src/core/db.js';
+import * as testHelpers from './helpers.mjs';
 
-const { Polls, Admin } = require('../src/core/index');
-const { HOUR, DAY } = require('../src/time');
-const { db } = require('../src/core/db');
-const testHelpers = require('./helpers');
+use(chaiAsPromised);
 
 describe('Polls', async () => {
   const HOUSE = testHelpers.generateSlackId();

--- a/test/things.test.mjs
+++ b/test/things.test.mjs
@@ -1,12 +1,11 @@
-const { expect } = require('chai');
-const chai = require('chai');
-const chaiAsPromised = require('chai-as-promised');
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 
-chai.use(chaiAsPromised);
+import { Things, Hearts, Polls, Admin } from '../src/core/index.js';
+import { HOUR, DAY } from '../src/time.js';
+import * as testHelpers from './helpers.mjs';
 
-const { Things, Hearts, Polls, Admin } = require('../src/core/index');
-const { HOUR, DAY } = require('../src/time');
-const testHelpers = require('./helpers');
+use(chaiAsPromised);
 
 describe('Things', async () => {
   const { HEART_UNKNOWN } = Hearts;


### PR DESCRIPTION
## Summary

- Bumps `chai` 4.5.0 → 6.2.2 and `chai-as-promised` 7.1.2 → 8.0.2 (both ESM-only since their respective majors)
- Drops `chai-almost` (last published 2016, CJS-only, incompatible with Chai 5+)
- Renames `test/*.js` → `test/*.mjs` so test files can use ESM `import` without affecting `src/`, which stays CommonJS
- Replaces 63 `chai-almost` call sites with the built-in `closeTo` matcher

## Approach

Going with option 1 from #317 (convert `test/` to ESM). Node 22's CJS named-export detection lets the `.mjs` tests import the unchanged CJS source cleanly:

```js
import { Admin } from '../src/core/index.js';
```

`chai-almost` rewrites:
- `expect(x).to.almost.equal(y)` → `expect(x).to.be.closeTo(y, 1e-6)`
- `expect(x).to.be.almost(y, tol)` → `expect(x).to.be.closeTo(y, tol)`

`1e-6` matches chai-almost's `DEFAULT_TOLERANCE`. All current usages are scalar; chai-almost's deep-equal-with-tolerance feature isn't used anywhere in the suite.

## Notes

The issue itself recommended deferring this until there's a concrete reason (CVE in Chai 4 or a Chai 5+ feature we want). There still isn't one — this is opt-in modernization to clear the deferred-upgrade backlog. If we'd rather stay on Chai 4, close this and #317.

Closes #317

## Test plan
- [x] `pnpm run lint` — clean
- [x] `pnpm test` — 178 passing
- [x] CJS `src/` still loads (`require('./src/core/index')`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)