### PR TITLE
fix(bolt): skip app_home_opened bookkeeping when channel is unset

### DIFF
--- a/src/bolt/chores/handlers/events.js
+++ b/src/bolt/chores/handlers/events.js
@@ -47,6 +47,7 @@ module.exports = (app) => {
     await common.publishHome(app, choresConf.oauth, residentId, view);
 
     // This bookkeeping is done after returning the view
+    if (!choresConf.channel) { return; }
 
     // Resolve any claims
     for (const resolvedClaim of await Chores.resolveChoreClaims(houseId, now)) {

--- a/src/bolt/hearts/handlers/events.js
+++ b/src/bolt/hearts/handlers/events.js
@@ -87,6 +87,7 @@ module.exports = (app) => {
     await common.publishHome(app, heartsConf.oauth, residentId, view);
 
     // This bookkeeping is done after returning the view
+    if (!heartsConf.channel) { return; }
 
     // Resolve any challanges
     for (const resolvedChallenge of await Hearts.resolveChallenges(houseId, now)) {

--- a/src/bolt/things/handlers/events.js
+++ b/src/bolt/things/handlers/events.js
@@ -47,6 +47,7 @@ module.exports = (app) => {
     await common.publishHome(app, thingsConf.oauth, residentId, view);
 
     // This bookkeeping is done after returning the view
+    if (!thingsConf.channel) { return; }
 
     // Resolve any buys
     for (const resolvedBuy of await Things.resolveThingBuys(houseId, now)) {


### PR DESCRIPTION
## Summary
- Wraps the `app_home_opened` bookkeeping block in a `heartsConf.channel` (and analogous `choresConf.channel` / `thingsConf.channel`) guard so it no-ops when the app is freshly installed and no channel has been picked yet.
- Fixes the `missing required field: channel` crash from `chat.postEphemeral` / `chat.postMessage` reproed in #318.
- Applied the same guard to chores and things for consistency, even though things only routes through `updateVoteResults` (channel from poll metadata) — proposals/buys can't exist without a channel set, so the early return is a safe no-op there.

## Test plan
- [x] `pnpm run lint`
- [ ] Reinstall Hearts in a workspace, open the app home before running `/hearts-channel`, confirm no `invalid_arguments` error in logs and the intro view still renders.

Fixes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)