### PR TITLE
feat(bolt): enable Messages tab across all apps

### DIFF
--- a/.manifest/chores-dev.yaml
+++ b/.manifest/chores-dev.yaml
@@ -5,8 +5,8 @@ display_information:
 features:
   app_home:
     home_tab_enabled: true
-    messages_tab_enabled: false
-    messages_tab_read_only_enabled: true
+    messages_tab_enabled: true
+    messages_tab_read_only_enabled: false
   bot_user:
     display_name: Chores-dev
     always_online: true
@@ -48,6 +48,7 @@ oauth_config:
       - files:read
       - groups:history
       - groups:read
+      - im:history
       - users:read
       - files:write
   pkce_enabled: false
@@ -57,6 +58,7 @@ settings:
     bot_events:
       - app_home_opened
       - app_uninstalled
+      - message.im
       - user_change
   interactivity:
     is_enabled: true

--- a/.manifest/chores.yaml
+++ b/.manifest/chores.yaml
@@ -5,8 +5,8 @@ display_information:
 features:
   app_home:
     home_tab_enabled: true
-    messages_tab_enabled: false
-    messages_tab_read_only_enabled: true
+    messages_tab_enabled: true
+    messages_tab_read_only_enabled: false
   bot_user:
     display_name: Chores
     always_online: true
@@ -48,6 +48,7 @@ oauth_config:
       - files:read
       - groups:history
       - groups:read
+      - im:history
       - users:read
       - files:write
   pkce_enabled: false
@@ -57,6 +58,7 @@ settings:
     bot_events:
       - app_home_opened
       - app_uninstalled
+      - message.im
       - user_change
   interactivity:
     is_enabled: true

--- a/.manifest/hearts-dev.yaml
+++ b/.manifest/hearts-dev.yaml
@@ -6,8 +6,8 @@ display_information:
 features:
   app_home:
     home_tab_enabled: true
-    messages_tab_enabled: false
-    messages_tab_read_only_enabled: true
+    messages_tab_enabled: true
+    messages_tab_read_only_enabled: false
   bot_user:
     display_name: Hearts-dev
     always_online: true
@@ -39,9 +39,10 @@ oauth_config:
       - chat:write
       - commands
       - groups:history
+      - groups:read
+      - im:history
       - reactions:write
       - users:read
-      - groups:read
   pkce_enabled: false
 settings:
   event_subscriptions:
@@ -52,6 +53,7 @@ settings:
       - channel_created
       - message.channels
       - message.groups
+      - message.im
       - user_change
   interactivity:
     is_enabled: true

--- a/.manifest/hearts.yaml
+++ b/.manifest/hearts.yaml
@@ -6,8 +6,8 @@ display_information:
 features:
   app_home:
     home_tab_enabled: true
-    messages_tab_enabled: false
-    messages_tab_read_only_enabled: true
+    messages_tab_enabled: true
+    messages_tab_read_only_enabled: false
   bot_user:
     display_name: Hearts
     always_online: true
@@ -39,9 +39,10 @@ oauth_config:
       - chat:write
       - commands
       - groups:history
+      - groups:read
+      - im:history
       - reactions:write
       - users:read
-      - groups:read
   pkce_enabled: false
 settings:
   event_subscriptions:
@@ -52,6 +53,7 @@ settings:
       - channel_created
       - message.channels
       - message.groups
+      - message.im
       - user_change
   interactivity:
     is_enabled: true

--- a/.manifest/things-dev.yaml
+++ b/.manifest/things-dev.yaml
@@ -6,8 +6,8 @@ display_information:
 features:
   app_home:
     home_tab_enabled: true
-    messages_tab_enabled: false
-    messages_tab_read_only_enabled: true
+    messages_tab_enabled: true
+    messages_tab_read_only_enabled: false
   bot_user:
     display_name: Things-dev
     always_online: true
@@ -41,6 +41,7 @@ oauth_config:
       - users:read
       - channels:read
       - groups:read
+      - im:history
   pkce_enabled: false
 settings:
   event_subscriptions:
@@ -48,6 +49,7 @@ settings:
     bot_events:
       - app_home_opened
       - app_uninstalled
+      - message.im
       - user_change
   interactivity:
     is_enabled: true

--- a/.manifest/things.yaml
+++ b/.manifest/things.yaml
@@ -6,8 +6,8 @@ display_information:
 features:
   app_home:
     home_tab_enabled: true
-    messages_tab_enabled: false
-    messages_tab_read_only_enabled: true
+    messages_tab_enabled: true
+    messages_tab_read_only_enabled: false
   bot_user:
     display_name: Things
     always_online: true
@@ -41,6 +41,7 @@ oauth_config:
       - users:read
       - channels:read
       - groups:read
+      - im:history
   pkce_enabled: false
 settings:
   event_subscriptions:
@@ -48,6 +49,7 @@ settings:
     bot_events:
       - app_home_opened
       - app_uninstalled
+      - message.im
       - user_change
   interactivity:
     is_enabled: true

--- a/src/bolt/chores/handlers/events.js
+++ b/src/bolt/chores/handlers/events.js
@@ -26,6 +26,15 @@ module.exports = (app) => {
     await common.pruneWorkspaceMember(user.team_id, user);
   });
 
+  // Direct message (placeholder for AI chat)
+  app.event('message', async ({ payload }) => {
+    if (payload.channel_type !== 'im') { return; }
+    if (payload.subtype) { return; }
+
+    console.log(`chores message.im - ${payload.user}`);
+    // TODO: AI chat handler
+  });
+
   // App home opened
   app.event('app_home_opened', async ({ body, event }) => {
     if (event.tab !== 'home') { return; }

--- a/src/bolt/hearts/handlers/events.js
+++ b/src/bolt/hearts/handlers/events.js
@@ -43,6 +43,8 @@ module.exports = (app) => {
 
   // Message
   app.event('message', async ({ payload }) => {
+    if (payload.channel_type === 'im') { return; }
+
     const karmaRecipients = Hearts.getKarmaRecipients(payload.text);
 
     if (karmaRecipients.length > 0) {
@@ -65,6 +67,15 @@ module.exports = (app) => {
 
       await common.addReaction(app, heartsConf.oauth, payload, numbers[karmaRecipients.length]);
     }
+  });
+
+  // Direct message (placeholder for AI chat)
+  app.event('message', async ({ payload }) => {
+    if (payload.channel_type !== 'im') { return; }
+    if (payload.subtype) { return; }
+
+    console.log(`hearts message.im - ${payload.user}`);
+    // TODO: AI chat handler
   });
 
   // App home opened

--- a/src/bolt/things/handlers/events.js
+++ b/src/bolt/things/handlers/events.js
@@ -27,6 +27,15 @@ module.exports = (app) => {
     await common.pruneWorkspaceMember(user.team_id, user);
   });
 
+  // Direct message (placeholder for AI chat)
+  app.event('message', async ({ payload }) => {
+    if (payload.channel_type !== 'im') { return; }
+    if (payload.subtype) { return; }
+
+    console.log(`things message.im - ${payload.user}`);
+    // TODO: AI chat handler
+  });
+
   // App home opened
   app.event('app_home_opened', async ({ body, event }) => {
     if (event.tab !== 'home') { return; }


### PR DESCRIPTION
## Summary

- Flip `messages_tab_enabled` to `true` and `messages_tab_read_only_enabled` to `false` across all 6 manifests (chores/hearts/things, prod + dev).
- Add `im:history` bot scope and `message.im` event subscription so DMs reach the bot.
- Add a logging-only `message.im` handler in each app's `events.js` as a placeholder for future AI chat logic.
- Add a `channel_type === 'im'` guard to the existing hearts karma message handler so DMs don't trigger karma scoring.

Groundwork for an AI-powered chat feature; no user-visible reply logic yet.

## Caveats

- `im:history` is a new scope, so **existing workspaces will need to re-authorize** before DMs reach the bot.
- With `read_only: false` and only a logging stub, DMs currently get no reply. Replacing the `// TODO` with real logic is a follow-up.

## Test plan

- [x] Lint passes (`pnpm run lint`)
- [ ] Reinstall a dev app in a test workspace and confirm Messages tab appears
- [ ] Send a DM to the bot and confirm `message.im` arrives in logs
- [ ] In a regular channel, post `+@user` and confirm karma still works
- [ ] In a DM, post `+@user` and confirm karma is *not* awarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)