### PR TITLE
feat(chores): let creators and admins delete unclaimed special chores

### DIFF
--- a/src/bolt/chores/handlers/actions.js
+++ b/src/bolt/chores/handlers/actions.js
@@ -479,7 +479,7 @@ module.exports = (app) => {
     const metadata = { description };
 
     if (privateMetadata.force) {
-      await Chores.executeChoreProposal(houseId, choreId, name, metadata, active, now);
+      await Chores.executeChoreProposal(houseId, residentId, choreId, name, metadata, active, now);
 
       const text = 'An admin just edited a chore';
       const blocks = views.choresProposeCallbackViewForce(privateMetadata, residentId, name, description);

--- a/src/bolt/chores/handlers/commands.js
+++ b/src/bolt/chores/handlers/commands.js
@@ -54,14 +54,46 @@ module.exports = (app) => {
   app.command('/chores-special', async ({ ack, command }) => {
     await ack();
 
-    const { now, houseId } = common.beginCommand('/chores-special', command);
+    const { now, houseId, residentId } = common.beginCommand('/chores-special', command);
     const { choresConf } = await Admin.getHouse(houseId);
 
     const currentSpecialChores = await Chores.getUnclaimedSpecialChoreValues(houseId, now);
     const futureSpecialChores = await Chores.getFutureSpecialChoreValues(houseId, now);
 
-    const view = views.choresSpecialListView(currentSpecialChores, futureSpecialChores);
+    // A special chore can be deleted by its creator, or by an admin
+    const isAdmin = await common.isAdmin(app, choresConf.oauth, residentId);
+    const deletableChores = [ ...currentSpecialChores, ...futureSpecialChores ]
+      .filter(cv => isAdmin || cv.metadata.createdBy === residentId);
+
+    const view = views.choresSpecialListView(currentSpecialChores, futureSpecialChores, deletableChores);
     await common.openView(app, choresConf.oauth, command.trigger_id, view);
+  });
+
+  // Callback: chores-special-delete-callback
+  app.view('chores-special-delete-callback', async ({ ack, body }) => {
+    await ack({ response_action: 'clear' });
+
+    const { now, houseId, residentId } = common.beginAction('chores-special-delete-callback', body);
+    const { choresConf } = await Admin.getHouse(houseId);
+
+    // The menu only lists chores the viewer may delete (filtered in the /chores-special handler),
+    // and Slack constrains a multi_static_select submission to the options we provided
+    const selectedOptions = common.getInputBlock(body, -1).chores.selected_options;
+
+    const deleted = [];
+    for (const option of selectedOptions) {
+      const { choreValueId } = JSON.parse(option.value);
+      const choreValue = await Chores.getSpecialChoreValue(choreValueId);
+
+      await Chores.deleteSpecialChore(houseId, choreValueId, residentId, now);
+      deleted.push(choreValue.metadata.name);
+    }
+
+    if (deleted.length > 0) {
+      const text = `<@${residentId}> deleted ${deleted.length} special chore${deleted.length === 1 ? '' : 's'}: ` +
+        deleted.map(name => `*${name}*`).join(', ');
+      await common.postMessage(app, choresConf, text);
+    }
   });
 
   // Slash command: /chores-activate

--- a/src/bolt/chores/views/commands.js
+++ b/src/bolt/chores/views/commands.js
@@ -1,5 +1,5 @@
 const common = require('../../common');
-const { TITLE, formatStats, formatTotalStats } = require('./utils');
+const { TITLE, formatStats, formatTotalStats, mapChoresValues } = require('./utils');
 
 // Command views
 
@@ -55,7 +55,7 @@ exports.choresStatsView = function (choreClaims, choreBreaks, choreStats, choreV
   };
 };
 
-exports.choresSpecialListView = function (currentChores, futureChores) {
+exports.choresSpecialListView = function (currentChores, futureChores, deletableChores = []) {
   const header = 'Special Chores';
 
   const currentText = '*Current*\n' +
@@ -79,6 +79,29 @@ exports.choresSpecialListView = function (currentChores, futureChores) {
   blocks.push(common.blockDivider());
   blocks.push(common.blockSection(currentText));
   blocks.push(common.blockSection(futureText));
+
+  // Offer a delete flow for chores the viewer created (or any chore, if an admin)
+  if (deletableChores.length > 0) {
+    blocks.push(common.blockDivider());
+    blocks.push(common.blockInput(
+      'Delete special chores',
+      {
+        action_id: 'chores',
+        type: 'multi_static_select',
+        placeholder: common.blockPlaintext('Choose special chores to delete'),
+        options: mapChoresValues(deletableChores.map(cv => ({ ...cv, choreValueId: cv.id }))),
+      },
+    ));
+
+    return {
+      type: 'modal',
+      callback_id: 'chores-special-delete-callback',
+      title: TITLE,
+      close: common.CLOSE,
+      submit: common.SUBMIT,
+      blocks,
+    };
+  }
 
   return {
     type: 'modal',

--- a/src/core/chores.js
+++ b/src/core/chores.js
@@ -268,6 +268,7 @@ exports.getUnclaimedSpecialChoreValues = async function (houseId, now) {
     .leftJoin('ChoreClaim', 'ChoreValue.id', 'ChoreClaim.choreValueId')
     .where('ChoreValue.houseId', houseId)
     .where('ChoreValue.valuedAt', '<=', now)
+    .where('ChoreValue.value', '>', 0) // Exclude deleted special chores
     .whereNull('ChoreValue.choreId')
     .groupBy('ChoreValue.id')
     .havingRaw('COUNT(CASE WHEN "ChoreClaim"."valid" = TRUE THEN 1 END) = 0') // No valid claims
@@ -278,6 +279,7 @@ exports.getFutureSpecialChoreValues = async function (houseId, now) {
   return db('ChoreValue')
     .where('ChoreValue.houseId', houseId)
     .where('ChoreValue.valuedAt', '>', now)
+    .where('ChoreValue.value', '>', 0) // Exclude deleted special chores
     .whereNull('ChoreValue.choreId')
     .orderBy('ChoreValue.valuedAt', 'asc')
     .returning('*');
@@ -487,8 +489,8 @@ exports.getUpdatedChoreValues = async function (houseId, updateTime) {
 };
 
 // Special chore values have choreId = null
-exports.addSpecialChoreValue = async function (houseId, name, description, value, valuedAt) {
-  const metadata = { name, description };
+exports.addSpecialChoreValue = async function (houseId, name, description, value, valuedAt, createdBy) {
+  const metadata = { name, description, createdBy };
   const choreValue = { houseId, value, valuedAt, metadata };
 
   return exports.addChoreValues(choreValue);
@@ -556,6 +558,29 @@ exports.claimSpecialChore = async function (houseId, choreValueId, claimedBy, cl
       pollId: poll.id,
       metadata: { ...choreValue.metadata, timeSpent },
     })
+    .returning('*');
+};
+
+// Deletes an unclaimed special chore by zeroing its value; the value > 0 filter then hides it
+// from the claimable and future lists, and it nets out of the obligation total automatically.
+// The initial value is preserved in metadata for auditability.
+exports.deleteSpecialChore = async function (houseId, choreValueId, deletedBy, now) {
+  const choreValue = await exports.getSpecialChoreValue(choreValueId);
+  assert(choreValue && choreValue.choreId === null, 'Not a special chore!');
+
+  // Cannot delete a chore which has been done, or has a claim in progress
+  const blockingClaims = await db('ChoreClaim')
+    .where({ choreValueId })
+    .where(function () {
+      this.whereNull('resolvedAt').orWhere('valid', true);
+    });
+  assert(blockingClaims.length === 0, 'Cannot delete a claimed special chore!');
+
+  const metadata = { ...choreValue.metadata, deletedBy, deletedAt: now, initialValue: choreValue.value };
+
+  return db('ChoreValue')
+    .where({ id: choreValueId, houseId })
+    .update({ value: 0, metadata })
     .returning('*');
 };
 
@@ -836,11 +861,11 @@ exports.getSpecialChoreProposalMinVotes = async function (houseId, value, now) {
   return Math.min(Math.max(numVotes, minVotes), maxVotes);
 };
 
-exports.executeChoreProposal = async function (houseId, choreId, name, metadata, active, now) {
+exports.executeChoreProposal = async function (houseId, proposedBy, choreId, name, metadata, active, now) {
   if (metadata.value) {
     // Add a special chore
     const { description, value, valuedAt } = metadata;
-    await exports.addSpecialChoreValue(houseId, name, description, value, valuedAt);
+    await exports.addSpecialChoreValue(houseId, name, description, value, valuedAt, proposedBy);
   } else if (!choreId) {
     // Add a regular chore
     const [ chore ] = await exports.addChore(houseId, name, metadata);
@@ -858,8 +883,8 @@ exports.resolveChoreProposal = async function (proposalId, now) {
   assert(!proposal.resolvedAt, 'Proposal already resolved!');
 
   if (await Polls.isPollValid(proposal.pollId, now)) {
-    const { houseId, choreId, name, metadata, active } = proposal;
-    await exports.executeChoreProposal(houseId, choreId, name, metadata, active, now);
+    const { houseId, proposedBy, choreId, name, metadata, active } = proposal;
+    await exports.executeChoreProposal(houseId, proposedBy, choreId, name, metadata, active, now);
   }
 
   return db('ChoreProposal')

--- a/test/chores.test.js
+++ b/test/chores.test.js
@@ -808,6 +808,47 @@ describe('Chores', async () => {
       expect(resolvedClaim.resolvedAt.getTime()).to.equal(challengeEnd.getTime());
     });
 
+    it('can delete an unclaimed special chore', async () => {
+      const [ name, description, value ] = [ 'Special Chore', 'Complicated task', 55 ];
+      await Chores.addSpecialChoreValue(HOUSE, name, description, value, now, RESIDENT1);
+
+      // The chore is claimable, and weighs on the special chore balance
+      let choreValues = await Chores.getUnclaimedSpecialChoreValues(HOUSE, now);
+      expect(choreValues.length).to.equal(1);
+      expect(await Chores.getSpecialChoreBalance(HOUSE, now)).to.equal(15 - 55);
+
+      await Chores.deleteSpecialChore(HOUSE, choreValues[0].id, RESIDENT1, now);
+
+      // The chore is gone, and the obligation is nullified as though it never existed
+      choreValues = await Chores.getUnclaimedSpecialChoreValues(HOUSE, now);
+      expect(choreValues.length).to.equal(0);
+      expect(await Chores.getSpecialChoreBalance(HOUSE, now)).to.equal(15);
+    });
+
+    it('can delete a future special chore', async () => {
+      const [ name, description, value ] = [ 'Special Chore', 'Complicated task', 15 ];
+      await Chores.addSpecialChoreValue(HOUSE, name, description, value, soon, RESIDENT1);
+
+      let choreValues = await Chores.getFutureSpecialChoreValues(HOUSE, now);
+      expect(choreValues.length).to.equal(1);
+
+      await Chores.deleteSpecialChore(HOUSE, choreValues[0].id, RESIDENT1, now);
+
+      choreValues = await Chores.getFutureSpecialChoreValues(HOUSE, now);
+      expect(choreValues.length).to.equal(0);
+    });
+
+    it('cannot delete a claimed special chore', async () => {
+      const [ name, description, value ] = [ 'Special Chore', 'Complicated task', 15 ];
+      await Chores.addSpecialChoreValue(HOUSE, name, description, value, now, RESIDENT1);
+
+      const [ choreValue ] = await Chores.getUnclaimedSpecialChoreValues(HOUSE, now);
+      await Chores.claimSpecialChore(HOUSE, choreValue.id, RESIDENT1, now, 20);
+
+      await expect(Chores.deleteSpecialChore(HOUSE, choreValue.id, RESIDENT1, now))
+        .to.be.rejectedWith('Cannot delete a claimed special chore!');
+    });
+
     it('can get the latest chore claim', async () => {
       await db('ChoreValue').insert([ { houseId: HOUSE, choreId: dishes.id, valuedAt: now, value: 10 } ]);
 


### PR DESCRIPTION
## What

Adds a delete flow for special chores. Via the existing `/chores-special` command, the chore's **creator** or a workspace **admin** can remove unclaimed special chores — selecting one or more from a multi-select that only lists chores they're allowed to delete.

This is the escape hatch we landed on after a long design discussion: rather than capping or auto-expiring special chores (both of which raised paternalism / trustworthy-totals objections), we keep creation permissive and make over-creation *correctable by exception*. Deleting only ever reduces obligation, so it can't be used to grief anyone, which is why a creator-or-admin gate (no vote) is appropriate.

## How

Deletion **zeroes the special chore's value** in place, preserving the row (no hard delete) with `deletedBy` / `deletedAt` / `initialValue` recorded in metadata for auditability. From there the existing machinery does the rest:

- the `value > 0` filter on `getUnclaimedSpecialChoreValues` and `getFutureSpecialChoreValues` hides it from the claimable and future lists; and
- it nets out of `getSpecialChoreTotal` automatically — a zero contributes nothing to the sum.

So `getSpecialChoreTotal` is untouched, and the queryable "is it deleted?" state lives in the `value` column (a real column, `value > 0`), with metadata used purely as annotation. The creator is recorded in `metadata.createdBy`, threaded through the proposal flow (`resolveChoreProposal → executeChoreProposal → addSpecialChoreValue`).

Authorization lives in the bolt layer (matching `/chores-reset`); the core function is permission-agnostic and asserts the target is a special chore with no valid or in-flight claim.

## Tests

Three new core tests: delete an unclaimed chore (obligation returns to allowance), delete a future chore, and reject deleting a claimed one. Full suite green (184 passing) against a local Postgres.

## Notes

- Branch is named `expire-special-chores` from the original exploration; what shipped is owner/admin **delete**, not auto-expiry.
- Deliberately **out of scope** (per discussion): the issuance governor / hard cap and any month-end expiry. Real data shows special-chore usage is bimodal — most houses barely touch them, one house uses them as its whole workflow — so the economics redesign is a separate, segment-driven decision.
- A separate follow-up is parked to remove the (entirely unused — 0/163 ever future-dated) future-scheduling feature, which would let this drop the `value > 0` filter on the future query too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
