### PR TITLE
ci: fix docs-sync push authentication failure

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -73,7 +73,7 @@ jobs:
           git checkout -b "$BRANCH"
           git add docs/
           git commit -m "docs: update for PR #${{ github.event.pull_request.number }}"
-          git push origin "$BRANCH"
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" "$BRANCH"
           gh pr create \
             --title "docs: update for #${{ github.event.pull_request.number }}" \
             --body "Auto-generated docs sync for #${{ github.event.pull_request.number }} (${{ github.event.pull_request.title }})."


### PR DESCRIPTION
The docs-sync workflow failed at the `git push` step with "Password authentication is not supported." The persisted credentials from `actions/checkout` weren't available at push time because the `claude-code-action` step runs in between. This pushes via an authenticated remote URL using `GITHUB_TOKEN` directly so the docs-update branch can be created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)