### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,8 +6,8 @@ project = 'Chore Wheel'
 copyright = '2023, Kronosapiens Labs'
 author = 'Daniel Kronovet'
 
-release = '0.6'
-version = '0.6.0'
+release = '0.7'
+version = '0.7.0'
 
 # -- General configuration
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chorewheel",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Chore wheel x1000",
   "repository": "git@github.com:zaratanDotWorld/choreWheel.git",
   "author": "Daniel Kronovet <krono@zaratan.world>",


### PR DESCRIPTION
Bumps the version to **0.7.0** in the two places it lives:

- `package.json`: `0.6.0` → `0.7.0`
- `docs/conf.py`: `release = '0.6'` → `'0.7'`, `version = '0.6.0'` → `'0.7.0'`

### Why now
v0.7.0 is the **last release on the current AWS stack**, cut immediately before the Render + Neon infra migration (#335). That migration is not user-facing, so it stays version-neutral — this tag captures the accumulated code first; the next *feature* release will be 0.8.0.

It's also overdue on its own merits: 121 commits since v0.6.0 (Feb 2025), including 22 feats and 23 fixes, with zero new DB migrations. 0.7.0 (minor) fits the project's all-minor, pre-1.0 cadence.

### Sequencing
Tag `v0.7.0` is cut from `main` **after this merges and before #335 merges**. No version bump lives inside the migration PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)