### PR TITLE
feat(deploy): add RDS→Neon data-migration script

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -25,30 +25,19 @@ Delete this file once cutover is complete and AWS is decommissioned.
 ## Step 1 — Copy data (RDS `mirror` → Neon `neondb`)
 
 Run this twice: now, to populate Neon so the preDeploy migrate no-ops and Render can be smoke-tested against real data; and again at cutover (Step 4) to capture writes since.
-The dump contains Slack **OAuth bot tokens** from the installation store.
-Treat any dump file as a secret; prefer the direct pipe (Option B), which persists nothing to disk.
-Three gotchas bite every RDS → Neon dump:
+The dump contains Slack **OAuth bot tokens** from the installation store, so the script streams `pg_dump` straight into Neon and never writes a dump file to disk.
 
-1. **Client version ≥ 17.** `pg_dump` must be at least the server version (RDS is 17.7). Local Homebrew tooling is 18.4, which is fine. In pgAdmin, if it errors on version, point *Preferences → Paths → Binary paths* at `/opt/homebrew/bin`.
-2. **Strip ownership/privileges.** RDS objects are owned by `postgres`/`mirror`, roles that don't exist on Neon. Restoring them as-is fails. Use `--no-owner --no-privileges` (CLI) or check "Do not save → Owner" and "Privileges" in pgAdmin's Backup *and* Restore dialogs.
-3. **Database names differ.** Dump from `mirror`, restore into `neondb`.
-
-### Option A — pgAdmin (GUI)
-
-Register the Neon server (host from the direct connection string, port `5432`, database `neondb`, user `neondb_owner`, **SSL mode: Require**).
-Backup: right-click RDS `mirror` → *Backup…* → Format **Custom** → set the Owner/Privileges options → save `mirror.dump`.
-Restore: right-click Neon `neondb` → *Restore…* → Format **Custom** → select `mirror.dump` → same Owner/Privileges options.
-
-### Option B — CLI (direct pipe, nothing written to disk)
+Run `scripts/migrate-db.sh` from the repo root:
 
 ```sh
-# RDS source: PG_CONNECTION_PROD from .env (read-only). NEON: the direct connection string.
-RDS=$(node -e "require('dotenv').config({quiet:true}); process.stdout.write(process.env.PG_CONNECTION_PROD)")
-NEON='postgresql://neondb_owner:...@ep-...us-west-2.aws.neon.tech/neondb?sslmode=require'
-
-PGSSLMODE=require pg_dump "$RDS" --no-owner --no-privileges --no-acl \
-  | psql "$NEON" -v ON_ERROR_STOP=1
+SOURCE_URL=$(node -e "require('dotenv').config({quiet:true});process.stdout.write(process.env.PG_CONNECTION_PROD)") \
+TARGET_URL=$(npx neonctl@latest connection-string --project-id noisy-poetry-20219969) \
+./scripts/migrate-db.sh
 ```
+
+`SOURCE_URL` is RDS (your `.env` `PG_CONNECTION_PROD`, while it still points at RDS); `TARGET_URL` is the Neon **direct** endpoint. Pass `-y` to skip the confirmation prompt on re-runs.
+
+The script resets the target schema and restores in one transaction (a failed run leaves Neon untouched; re-runs are safe), then verifies source-vs-target row counts. It handles the three things that bite a manual copy: it checks `pg_dump` is ≥ 17; strips ownership/privileges (`--no-owner --no-privileges --no-acl`, since RDS's `postgres`/`mirror` roles don't exist on Neon); and restores into `neondb` regardless of the source db name.
 
 ## Step 2 — Verify parity
 
@@ -59,7 +48,7 @@ NODE_ENV=production PG_CONNECTION_PROD="$NEON" npx knex migrate:latest
 # expect: "Already up to date"
 ```
 
-Spot-check row counts against RDS for the core tables (e.g. `chore_claims`, `hearts`, `things`, and the installation/OAuth table) and confirm all expected tables are present.
+`scripts/migrate-db.sh` already compared every table's row counts; this step just confirms schema + migration-history parity via knex (the dump carries the `knex_migrations` history, so it should be a clean no-op).
 
 ## Step 3 — Wire the app
 

--- a/scripts/migrate-db.sh
+++ b/scripts/migrate-db.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# migrate-db.sh — copy the ChoreWheel database from RDS (source) into Neon (target).
+#
+# One-time data-migration tool for the Render/Neon move (see MIGRATION.md).
+# Idempotent: wraps a target schema reset + fresh restore in a SINGLE transaction,
+# so a failed run leaves the target untouched and a successful run fully replaces
+# it. Safe to run for the initial load and again for the cutover re-sync, and safe
+# against a target that already holds stale data or an empty preDeploy-created
+# schema. Streams pg_dump straight into psql — the dump carries Slack OAuth tokens,
+# so nothing is ever written to disk.
+#
+# Usage (from the repo root):
+#   SOURCE_URL=$(node -e "require('dotenv').config({quiet:true});process.stdout.write(process.env.PG_CONNECTION_PROD)") \
+#   TARGET_URL=$(npx neonctl@latest connection-string --project-id noisy-poetry-20219969) \
+#   ./scripts/migrate-db.sh
+#
+#   -y / FORCE=1   skip the confirmation prompt (non-interactive re-runs)
+#
+# Requires pg_dump/psql >= the source server major version (Postgres 17).
+
+set -euo pipefail
+
+if [[ "${1:-}" == "-y" || "${FORCE:-}" == "1" ]]; then CONFIRM=false; else CONFIRM=true; fi
+
+: "${SOURCE_URL:?Set SOURCE_URL to the RDS connection string — see usage at top of script}"
+: "${TARGET_URL:?Set TARGET_URL to the Neon DIRECT connection string — see usage at top of script}"
+
+export PGSSLMODE="${PGSSLMODE:-require}"            # RDS enforces SSL; Neon requires it
+export PGCONNECT_TIMEOUT="${PGCONNECT_TIMEOUT:-10}"
+
+mask()    { sed -E 's#(://[^:]+:)[^@]+(@)#\1********\2#'; }
+host_of() { sed -E 's#.*@([^/?]+).*#\1#'; }
+
+# pg_dump must be at least the source server major version (source is Postgres 17).
+dump_major=$(pg_dump --version | grep -oE '[0-9]+' | head -1)
+if (( dump_major < 17 )); then
+  echo "ERROR: pg_dump is v${dump_major}; need >= 17 to dump the Postgres 17 source." >&2
+  echo "       macOS: 'brew install postgresql@17', or use the /opt/homebrew/bin tools." >&2
+  exit 1
+fi
+
+src_host=$(printf '%s' "$SOURCE_URL" | host_of)
+tgt_host=$(printf '%s' "$TARGET_URL" | host_of)
+if [[ "$src_host" == "$tgt_host" ]]; then
+  echo "ERROR: source and target are the same host (${src_host}). Refusing to run." >&2
+  exit 1
+fi
+
+echo "Source (read-only): $(printf '%s' "$SOURCE_URL" | mask)"
+echo "Target (REPLACED):  $(printf '%s' "$TARGET_URL" | mask)"
+echo
+
+echo "Checking connectivity..."
+psql "$SOURCE_URL" -tAc 'select 1' >/dev/null
+psql "$TARGET_URL" -tAc 'select 1' >/dev/null
+echo "  both reachable."
+
+if $CONFIRM; then
+  echo
+  echo "This REPLACES all data in the target (${tgt_host}) with a fresh copy of the source."
+  read -r -p "Type 'yes' to continue: " reply
+  [[ "$reply" == "yes" ]] || { echo "Aborted."; exit 1; }
+fi
+
+echo
+echo "Migrating (schema reset + restore, single transaction, streaming)..."
+{
+  echo 'DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;'
+  pg_dump "$SOURCE_URL" --no-owner --no-privileges --no-acl
+} | psql "$TARGET_URL" --single-transaction -v ON_ERROR_STOP=1 -q
+echo "  restore committed."
+
+echo
+echo "Verifying row counts (source vs target)..."
+printf '%-34s %10s %10s\n' table source target
+mismatch=0
+while IFS= read -r t; do
+  [[ -z "$t" ]] && continue
+  s=$(psql "$SOURCE_URL" -tAc "select count(*) from \"$t\"")
+  d=$(psql "$TARGET_URL" -tAc "select count(*) from \"$t\"")
+  flag=""; [[ "$s" != "$d" ]] && { flag="  <-- MISMATCH"; mismatch=1; }
+  printf '%-34s %10s %10s%s\n' "$t" "$s" "$d" "$flag"
+done < <(psql "$TARGET_URL" -tAc "select tablename from pg_tables where schemaname='public' order by tablename")
+
+echo
+if (( mismatch )); then echo "DONE with MISMATCHES — investigate above."; exit 1; fi
+echo "DONE — all row counts match."


### PR DESCRIPTION
Follow-up to #335. Adds `scripts/migrate-db.sh` — an idempotent `pg_dump | psql` copy for the RDS → Neon data migration — and points MIGRATION.md Step 1 at it instead of the manual pgAdmin walkthrough.

The script resets the target's public schema and restores in a single transaction (a failed run leaves the target untouched, and re-runs are safe), then verifies source-vs-target row counts. It streams the dump straight into psql so nothing is written to disk (the dump carries Slack OAuth tokens), checks `pg_dump` is ≥ 17, strips ownership/privileges (RDS's `postgres`/`mirror` roles don't exist on Neon), and restores into `neondb` regardless of the source db name. We run it once for the initial load and again as a fresh re-sync at cutover.

Already exercised end-to-end against prod RDS → Neon: data copied, row counts matched, and `knex migrate:latest` against Neon reports "Already up to date".

🤖 Generated with [Claude Code](https://claude.com/claude-code)