### PR TITLE
Scale monthly chore point cap to obligation, add capped message

### DIFF
--- a/src/bolt/chores/views/events.js
+++ b/src/bolt/chores/views/events.js
@@ -28,6 +28,8 @@ exports.choresOnboardView = function () {
 
 exports.choresHomeView = function (choreChannel, choreStats, numActive) {
   const { pointsEarned, pointsOwed } = choreStats;
+  const pointsCap = pointsOwed * Chores.params.pointsCapMultiplier;
+
   const progressEmoji = pointsOwed - pointsEarned < Chores.params.penaltyIncrement
     ? ':white_check_mark:'
     : ':muscle::skin-tone-4:';
@@ -43,13 +45,14 @@ exports.choresHomeView = function (choreChannel, choreStats, numActive) {
   const pointsText = pointsOwed > 0
     ? `You've earned *${pointsEarned} / ${pointsOwed} points* this month ${progressEmoji}`
     : '*You are exempt from chores!* :tada:';
+  const cappedText = `You've hit your monthly max of *${pointsCap} points*! :confetti_ball:`;
   const activeText = `There are *${numActive} people* around today :sunny:`;
   const channelText = `Events will be posted in <#${choreChannel}> :mailbox_with_mail:`;
 
   const actions = [];
 
   if (pointsOwed > 0) {
-    if (Number(pointsEarned) < Number(pointsOwed) + Chores.params.pointsBuffer) {
+    if (pointsEarned < pointsCap) {
       actions.push(common.blockButton('chores-claim', ':hand::skin-tone-4: Claim a chore'));
     }
     actions.push(common.blockButton('chores-rank', ':scales: Set priorities'));
@@ -69,6 +72,11 @@ exports.choresHomeView = function (choreChannel, choreStats, numActive) {
   blocks.push(common.blockSection(common.feedbackLink));
   blocks.push(common.blockDivider());
   blocks.push(common.blockSection(pointsText));
+
+  if (pointsOwed > 0 && pointsEarned >= pointsCap) {
+    blocks.push(common.blockSection(cappedText));
+  }
+
   blocks.push(common.blockSection(activeText));
   blocks.push(common.blockSection(channelText));
   blocks.push(common.blockActions(actions));

--- a/src/core/chores.js
+++ b/src/core/chores.js
@@ -25,7 +25,7 @@ exports.params = {
   valueThreshold: 10,
   numResidentsThreshold: 4,
   pointsPerResident: 100,
-  pointsBuffer: 200,
+  pointsCapMultiplier: 3,
   inflationFactor: 1.02,
   displayThreshold: 0.5,
   penaltyDelay: DAY + 6 * HOUR, // TODO: make robust


### PR DESCRIPTION
Replaces the additive `pointsBuffer` (obligation + 200) with a proportional `pointsCapMultiplier` (obligation × 3), so a resident's monthly claim cap now scales with their actual obligation instead of handing disproportionate headroom to residents with reduced obligations (e.g. someone owing 50 was previously capped at 250 / 5× their share, now 150 / 3×). The default 100-point obligation is unchanged: 100 × 3 = 300, matching the old 100 + 200. Adds a celebratory home-view message when a resident reaches their cap, replacing the previously silent disappearance of the "Claim a chore" button. Also drops now-unnecessary `Number()` casts, since `pointsEarned` and `pointsOwed` are already numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)