### PR TITLE
fix(ci): pass --head to gh pr create in docs-sync workflow

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -75,6 +75,8 @@ jobs:
           git commit -m "docs: update for PR #${{ github.event.pull_request.number }}"
           git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" "$BRANCH"
           gh pr create \
+            --base main \
+            --head "$BRANCH" \
             --title "docs: update for #${{ github.event.pull_request.number }}" \
             --body "Auto-generated docs sync for #${{ github.event.pull_request.number }} (${{ github.event.pull_request.title }})."
         env:


### PR DESCRIPTION
The docs-sync workflow pushes the generated docs branch via an explicit authenticated URL rather than `git push -u`, so no upstream tracking ref is ever set. As a result `gh pr create` could not infer the head branch and aborted with "you must first push the current branch to a remote, or use the --head flag", failing the job. This passes `--head "$BRANCH"` (and `--base main`) explicitly so the PR opens without relying on tracking config.