### PR TITLE
docs: document monthly point cap in chores docs

### DIFF
--- a/docs/tools/chores.rst
+++ b/docs/tools/chores.rst
@@ -146,6 +146,9 @@ The app home is also the entryway into the basic functionality, described below:
   In the unlikely scenario that someone lies about doing a chore (or does an extremely poor job), the rest of the residents may downvote the claim.
   A failed claim returns the points to the chore, allowing someone else to do the job properly.
 
+  There's a monthly cap on how many points you can claim, equal to **3x your obligation** (so someone who owes 100 points can earn up to 300).
+  Once you hit that cap, the ``Claim a chore`` button disappears from the home page and is replaced with a congratulatory message.
+
 :guilabel:`Take a break`
   The point of Chores is to help folks clean up their own messes, with more points (roughly) meaning more mess.
   When someone is out of town, they aren't making a mess, and so they shouldn't owe as many points.


### PR DESCRIPTION
Picks up the docs-sync output for #338, which the workflow generated but never opened a PR for (that bug was fixed in #339).

Adds a note to the chores docs describing the monthly claim cap of 3x obligation and the congratulatory message that replaces the `Claim a chore` button once a resident hits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)